### PR TITLE
fix package type

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",
-  "type": "module",
   "homepage": "https://electron-vite.org",
   "scripts": {
     "format": "prettier --write .",


### PR DESCRIPTION
In the previous pr #5, it changes the package type from default to "module". It makes the preload to be built in .mjs extension.
We need to revert this change to make the renderer to load the preload script
Fix #6 