### PR TITLE
Automatic image resizing for captured camera/screen

### DIFF
--- a/src/renderer/src/hooks/utils/use-media-capture.tsx
+++ b/src/renderer/src/hooks/utils/use-media-capture.tsx
@@ -84,7 +84,7 @@ export function useMediaCapture() {
         return null;
       }
 
-      ctx.drawImage(bitmap, 0, 0);
+      ctx.drawImage(bitmap, 0, 0, width, height);
       const quality = getCompressionQuality();
       return canvas.toDataURL('image/jpeg', quality);
     } catch (error) {


### PR DESCRIPTION
when the image capture area is larger than maxWidth, currently ctx.drawImage crops the rest of the image.
This makes your waifu blind!
PR adds a resizing step to ctx.drawImage, so the waifu can see everything on the screen ^.^