### PR TITLE
feat: add upload image for button, and can preview and remove image by one click.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!-- PULL REQUEST TEMPLATE -->
+<!-- (Update "[ ]" to "[x]" to check a box) -->
+
+<!-- 感谢你的贡献 -->
+<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
+<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
+<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->
+
+## 动机
+
+<!-- 请在这里描述你的修改 -->
+<!-- 如果有相关讨论 issue 请链接到该处 -->
+<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
+<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
+<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
+<!-- 如 related to #59 -->
+
+## 解决方案
+
+<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->
+
+## 类型
+
+<!-- 本 PR 的类型（至少选择一个） -->
+
+-  [ ] :sparkles: feat: 添加新功能
+-  [ ] :bug: fix: 修复 bug
+-  [ ] :pencil: docs: 对文档进行修改
+-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
+-  [ ] :zap: perf: 提高性能的代码修改
+-  [ ] :technologist: dx: 优化开发体验
+-  [ ] :hammer: workflow: 工作流变动
+-  [ ] :label: types: 类型声明修改
+-  [ ] :construction: wip: 工作正在进行中
+-  [ ] :white_check_mark: test: 测试用例添加及修改
+-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
+-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
+-  [ ] :question: chore: 其它不涉及源码以及测试的修改
+-  [ ] :arrow_up: deps: 依赖项修改
+-  [ ] :bookmark: release: 发布新版本

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ release
 dist
 dist-ssr
 build
+electron.vite.config.*.mjs
 *.local
 .docusaurus
 .cache-loader

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-shadow */
-import { app, ipcMain, globalShortcut, desktopCapturer } from "electron";
+import { app, ipcMain, globalShortcut, desktopCapturer, screen } from "electron";
 import { electronApp, optimizer } from "@electron-toolkit/utils";
 import { WindowManager } from "./window-manager";
 import { MenuManager } from "./menu-manager";
@@ -70,6 +70,19 @@ function setupIPC(): void {
   ipcMain.handle('get-screen-capture', async () => {
     const sources = await desktopCapturer.getSources({ types: ['screen'] });
     return sources[0].id;
+  });
+
+  ipcMain.handle('get-cursor-window-point', () => {
+    const window = windowManager.getWindow();
+    if (!window) return null;
+
+    const bounds = window.getBounds();
+    const cursorPoint = screen.getCursorScreenPoint();
+
+    return {
+      x: cursorPoint.x - bounds.x,
+      y: cursorPoint.y - bounds.y,
+    };
   });
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -86,6 +86,9 @@ function setupIPC(): void {
   });
 }
 
+app.commandLine.appendSwitch('disable-renderer-backgrounding');
+app.commandLine.appendSwitch('disable-background-timer-throttling');
+
 app.whenReady().then(() => {
   electronApp.setAppUserModelId("com.electron");
 

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -23,6 +23,14 @@ export class WindowManager {
   // Track if mouse events are forcibly ignored
   private forceIgnoreMouse = false;
 
+  private getDefaultWindowSize(): { width: number; height: number } {
+    const { width, height } = screen.getPrimaryDisplay().workArea;
+    return {
+      width: Math.round(width * 0.5),
+      height: Math.round(height * 0.6),
+    };
+  }
+
   constructor() {
     ipcMain.on('renderer-ready-for-mode-change', (_event, newMode) => {
       if (newMode === 'pet') {
@@ -54,9 +62,10 @@ export class WindowManager {
   }
 
   createWindow(options: Electron.BrowserWindowConstructorOptions): BrowserWindow {
+    const { width, height } = this.getDefaultWindowSize();
     this.window = new BrowserWindow({
-      width: 900,
-      height: 670,
+      width,
+      height,
       show: false,
       transparent: true,
       backgroundColor: '#ffffff',
@@ -168,7 +177,8 @@ export class WindowManager {
     if (this.windowedBounds) {
       this.window.setBounds(this.windowedBounds);
     } else {
-      this.window.setSize(900, 670);
+      const { width, height } = this.getDefaultWindowSize();
+      this.window.setSize(width, height);
       this.window.center();
     }
 

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -80,6 +80,7 @@ export class WindowManager {
         sandbox: false,
         contextIsolation: true,
         nodeIntegration: true,
+        backgroundThrottling: false,
       },
       hasShadow: false,
       paintWhenInitiallyHidden: true,

--- a/src/renderer/WebSDK/src/lappdefine.ts
+++ b/src/renderer/WebSDK/src/lappdefine.ts
@@ -59,7 +59,7 @@ export function updateModelConfig(
   if (kScale !== undefined) {
     CurrentKScale = kScale;
   }
-  CurrentIdleMotionGroupName = idleMotionGroupName ?? 'Idle';
+  CurrentIdleMotionGroupName = idleMotionGroupName ?? null;
   // Update ModelDirSize when ModelDir changes
   ModelDirSize = ModelDir.length;
 }

--- a/src/renderer/WebSDK/src/lappdefine.ts
+++ b/src/renderer/WebSDK/src/lappdefine.ts
@@ -36,16 +36,30 @@ export let ResourcesPath = "";
 // Model directory and filename storage
 export let ModelDir: string[] = [];
 export let ModelFileNames: string[] = []; // New array to store model file names
+export let CurrentIdleMotionGroupName: string | null = 'Idle';
 
 // Function to update model configuration with both directory and file name
-export function updateModelConfig(resourcePath: string, modelDirectory: string, modelFileName: string, kScale?: number) {
-  console.log('Updating model config:', { resourcePath, modelDirectory, modelFileName, kScale });
+export function updateModelConfig(
+  resourcePath: string,
+  modelDirectory: string,
+  modelFileName: string,
+  kScale?: number,
+  idleMotionGroupName?: string,
+) {
+  console.log('Updating model config:', {
+    resourcePath,
+    modelDirectory,
+    modelFileName,
+    kScale,
+    idleMotionGroupName,
+  });
   ResourcesPath = resourcePath;
   ModelDir = [modelDirectory];
   ModelFileNames = [modelFileName]; // Store the actual model file name
   if (kScale !== undefined) {
     CurrentKScale = kScale;
   }
+  CurrentIdleMotionGroupName = idleMotionGroupName ?? 'Idle';
   // Update ModelDirSize when ModelDir changes
   ModelDirSize = ModelDir.length;
 }

--- a/src/renderer/WebSDK/src/lapplive2dmanager.ts
+++ b/src/renderer/WebSDK/src/lapplive2dmanager.ts
@@ -90,13 +90,30 @@ export class LAppLive2DManager {
    * @param y 画面のY座標
    */
   public onDrag(x: number, y: number): void {
+    const targetX = this._dragInputEnabled ? x : 0.0;
+    const targetY = this._dragInputEnabled ? y : 0.0;
     for (let i = 0; i < this._models.getSize(); i++) {
       const model: LAppModel = this.getModel(i)!;
 
       if (model) {
-        model.setDragging(x, y);
+        model.setDragging(targetX, targetY);
       }
     }
+  }
+
+  /**
+   * Enable/disable SDK built-in drag parameter input.
+   * When disabled, drag is forced to neutral and external systems (e.g. mixer) should drive pose.
+   */
+  public setDragInputEnabled(enabled: boolean): void {
+    this._dragInputEnabled = enabled;
+    if (!enabled) {
+      this.onDrag(0.0, 0.0);
+    }
+  }
+
+  public isDragInputEnabled(): boolean {
+    return this._dragInputEnabled;
   }
 
   /**
@@ -223,12 +240,14 @@ export class LAppLive2DManager {
     this._viewMatrix = new CubismMatrix44();
     this._models = new csmVector<LAppModel>();
     this._sceneIndex = 0;
+    this._dragInputEnabled = true;
     this.changeScene(this._sceneIndex);
   }
 
   _viewMatrix: CubismMatrix44; // モデル描画に用いるview行列
   _models: csmVector<LAppModel>; // モデルインスタンスのコンテナ
   _sceneIndex: number; // 表示するシーンのインデックス値
+  _dragInputEnabled: boolean;
   // モーション再生終了のコールバック関数
   _finishedMotion = (self: ACubismMotion): void => {
     LAppPal.printMessage('Motion Finished:');

--- a/src/renderer/WebSDK/src/lappmodel.ts
+++ b/src/renderer/WebSDK/src/lappmodel.ts
@@ -600,8 +600,14 @@ export class LAppModel extends CubismUserModel {
     ); // -10から10の値を加える
 
     // ドラッグによる目の向きの調整
-    this._model.addParameterValueById(this._idParamEyeBallX, this._dragX); // -1から1の値を加える
-    this._model.addParameterValueById(this._idParamEyeBallY, this._dragY);
+    this._model.addParameterValueById(this._idParamEyeBallX, this._dragX * 2.0); // -1から1の値を加える
+    if (this._idParamBodyAngleY) {
+      this._model.addParameterValueById(
+        this._idParamBodyAngleY,
+        this._dragY * 10
+      );
+    }
+    this._model.addParameterValueById(this._idParamEyeBallY, this._dragY * 2.0);
 
     // 呼吸など
     if (this._breath != null) {
@@ -1294,6 +1300,9 @@ export class LAppModel extends CubismUserModel {
       this._idParamBodyAngleX = idManager.getId(
         CubismDefaultParameterId.ParamBodyAngleX
       );
+      this._idParamBodyAngleY = idManager.getId(
+        CubismDefaultParameterId.ParamBodyAngleY
+      );
     } else {
       // Initialize handles with null to avoid undefined errors
       this._idParamAngleX = null;
@@ -1302,6 +1311,7 @@ export class LAppModel extends CubismUserModel {
       this._idParamEyeBallX = null;
       this._idParamEyeBallY = null;
       this._idParamBodyAngleX = null;
+      this._idParamBodyAngleY = null;
     }
 
     if (LAppDefine.MOCConsistencyValidationEnable) {
@@ -1329,6 +1339,7 @@ export class LAppModel extends CubismUserModel {
 
   _hitArea: csmVector<csmRect>;
   _userArea: csmVector<csmRect>;
+  _idParamBodyAngleY: CubismIdHandle;
 
   _idParamAngleX: CubismIdHandle; // パラメータID: ParamAngleX
   _idParamAngleY: CubismIdHandle; // パラメータID: ParamAngleY

--- a/src/renderer/WebSDK/src/lappmodel.ts
+++ b/src/renderer/WebSDK/src/lappmodel.ts
@@ -557,10 +557,12 @@ export class LAppModel extends CubismUserModel {
     this._model.loadParameters(); // 前回セーブされた状態をロード
     if (this._motionManager.isFinished()) {
       // モーションの再生がない場合、待機モーションの中からランダムで再生する
-      this.startRandomMotion(
-        LAppDefine.MotionGroupIdle,
-        LAppDefine.PriorityIdle
-      );
+      if (LAppDefine.CurrentIdleMotionGroupName) {
+        this.startRandomMotion(
+          LAppDefine.CurrentIdleMotionGroupName,
+          LAppDefine.PriorityIdle
+        );
+      }
     } else {
       motionUpdated = this._motionManager.updateMotion(
         this._model,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -29,6 +29,7 @@ import Background from "./components/canvas/background";
 import WebSocketStatus from "./components/canvas/ws-status";
 import Subtitle from "./components/canvas/subtitle";
 import { ModeProvider, useMode } from "./context/mode-context";
+import { MoodProvider } from "./context/mood-context";
 
 function AppContent(): JSX.Element {
   const [showSidebar, setShowSidebar] = useState(true);
@@ -175,24 +176,26 @@ function AppWithGlobalStyles(): JSX.Element {
           <CharacterConfigProvider>
             <ChatHistoryProvider>
               <AiStateProvider>
-                <ProactiveSpeakProvider>
-                  <Live2DConfigProvider>
-                    <SubtitleProvider>
-                      <VADProvider>
-                        <BgUrlProvider>
-                          <GroupProvider>
-                            <BrowserProvider>
-                              <WebSocketHandler>
-                                <Toaster />
-                                <AppContent />
-                              </WebSocketHandler>
-                            </BrowserProvider>
-                          </GroupProvider>
-                        </BgUrlProvider>
-                      </VADProvider>
-                    </SubtitleProvider>
-                  </Live2DConfigProvider>
-                </ProactiveSpeakProvider>
+                <MoodProvider>
+                  <ProactiveSpeakProvider>
+                    <Live2DConfigProvider>
+                      <SubtitleProvider>
+                        <VADProvider>
+                          <BgUrlProvider>
+                            <GroupProvider>
+                              <BrowserProvider>
+                                <WebSocketHandler>
+                                  <Toaster />
+                                  <AppContent />
+                                </WebSocketHandler>
+                              </BrowserProvider>
+                            </GroupProvider>
+                          </BgUrlProvider>
+                        </VADProvider>
+                      </SubtitleProvider>
+                    </Live2DConfigProvider>
+                  </ProactiveSpeakProvider>
+                </MoodProvider>
               </AiStateProvider>
             </ChatHistoryProvider>
           </CharacterConfigProvider>

--- a/src/renderer/src/components/canvas/live2d.tsx
+++ b/src/renderer/src/components/canvas/live2d.tsx
@@ -11,6 +11,7 @@ import { useLive2DResize } from "@/hooks/canvas/use-live2d-resize";
 import { useAiState, AiStateEnum } from "@/context/ai-state-context";
 import { useLive2DExpression } from "@/hooks/canvas/use-live2d-expression";
 import { useLive2DAppearance } from "@/hooks/canvas/use-live2d-appearance";
+import { useLive2DPoseMixer } from "@/hooks/canvas/use-live2d-pose-mixer";
 import { useForceIgnoreMouse } from "@/hooks/utils/use-force-ignore-mouse";
 import { useMode } from "@/context/mode-context";
 
@@ -28,7 +29,9 @@ export const Live2D = memo(
     const { resetExpression } = useLive2DExpression();
     const isPet = mode === 'pet';
 
+    // Keep this order stable: appearance/expression wrapper first, mixer wrapper second.
     useLive2DAppearance(modelInfo, persistentAppearance);
+    useLive2DPoseMixer(modelInfo?.url);
 
     // Get canvasRef from useLive2DResize
     const { canvasRef } = useLive2DResize({

--- a/src/renderer/src/components/canvas/live2d.tsx
+++ b/src/renderer/src/components/canvas/live2d.tsx
@@ -10,6 +10,7 @@ import { useLive2DModel } from "@/hooks/canvas/use-live2d-model";
 import { useLive2DResize } from "@/hooks/canvas/use-live2d-resize";
 import { useAiState, AiStateEnum } from "@/context/ai-state-context";
 import { useLive2DExpression } from "@/hooks/canvas/use-live2d-expression";
+import { useLive2DAppearance } from "@/hooks/canvas/use-live2d-appearance";
 import { useForceIgnoreMouse } from "@/hooks/utils/use-force-ignore-mouse";
 import { useMode } from "@/context/mode-context";
 
@@ -20,12 +21,14 @@ interface Live2DProps {
 export const Live2D = memo(
   ({ showSidebar }: Live2DProps): JSX.Element => {
     const { forceIgnoreMouse } = useForceIgnoreMouse();
-    const { modelInfo } = useLive2DConfig();
+    const { modelInfo, persistentAppearance } = useLive2DConfig();
     const { mode } = useMode();
     const internalContainerRef = useRef<HTMLDivElement>(null);
     const { aiState } = useAiState();
     const { resetExpression } = useLive2DExpression();
     const isPet = mode === 'pet';
+
+    useLive2DAppearance(modelInfo, persistentAppearance);
 
     // Get canvasRef from useLive2DResize
     const { canvasRef } = useLive2DResize({
@@ -49,11 +52,11 @@ export const Live2D = memo(
     useEffect(() => {
       if (aiState === AiStateEnum.IDLE) {
         const lappAdapter = (window as any).getLAppAdapter?.();
-        if (lappAdapter) {
+        if (lappAdapter && persistentAppearance === undefined) {
           resetExpression(lappAdapter, modelInfo);
         }
       }
-    }, [aiState, modelInfo, resetExpression]);
+    }, [aiState, modelInfo, persistentAppearance, resetExpression]);
 
     // Expose setExpression for console testing
     // useEffect(() => {

--- a/src/renderer/src/components/canvas/live2d.tsx
+++ b/src/renderer/src/components/canvas/live2d.tsx
@@ -46,7 +46,7 @@ export const Live2D = memo(
     // Setup hooks
     useIpcHandlers();
     useInterrupt();
-    useAudioTask();
+    useAudioTask({ managePlaybackCompletion: true });
 
     // Idle only clears the transient expression layer.
     useEffect(() => {

--- a/src/renderer/src/components/canvas/live2d.tsx
+++ b/src/renderer/src/components/canvas/live2d.tsx
@@ -48,15 +48,12 @@ export const Live2D = memo(
     useInterrupt();
     useAudioTask();
 
-    // Reset expression to default when AI state becomes idle
+    // Idle only clears the transient expression layer.
     useEffect(() => {
       if (aiState === AiStateEnum.IDLE) {
-        const lappAdapter = (window as any).getLAppAdapter?.();
-        if (lappAdapter && persistentAppearance === undefined) {
-          resetExpression(lappAdapter, modelInfo);
-        }
+        resetExpression();
       }
-    }, [aiState, modelInfo, persistentAppearance, resetExpression]);
+    }, [aiState, resetExpression]);
 
     // Expose setExpression for console testing
     // useEffect(() => {

--- a/src/renderer/src/components/canvas/live2d.tsx
+++ b/src/renderer/src/components/canvas/live2d.tsx
@@ -5,7 +5,6 @@ import { memo, useRef, useEffect } from "react";
 import { useLive2DConfig } from "@/context/live2d-config-context";
 import { useIpcHandlers } from "@/hooks/utils/use-ipc-handlers";
 import { useInterrupt } from "@/hooks/utils/use-interrupt";
-import { useAudioTask } from "@/hooks/utils/use-audio-task";
 import { useLive2DModel } from "@/hooks/canvas/use-live2d-model";
 import { useLive2DResize } from "@/hooks/canvas/use-live2d-resize";
 import { useAiState, AiStateEnum } from "@/context/ai-state-context";
@@ -49,8 +48,6 @@ export const Live2D = memo(
     // Setup hooks
     useIpcHandlers();
     useInterrupt();
-    useAudioTask({ managePlaybackCompletion: true });
-
     // Idle only clears the transient expression layer.
     useEffect(() => {
       if (aiState === AiStateEnum.IDLE) {
@@ -130,4 +127,4 @@ export const Live2D = memo(
 
 Live2D.displayName = "Live2D";
 
-export { useInterrupt, useAudioTask };
+export { useInterrupt };

--- a/src/renderer/src/components/canvas/ws-status.tsx
+++ b/src/renderer/src/components/canvas/ws-status.tsx
@@ -19,7 +19,7 @@ const MemoizedStatusContent = memo(StatusContent);
 // Main component
 const WebSocketStatus = memo((): JSX.Element => {
   const {
-    color, textKey, handleClick, isDisconnected,
+    color, textKey, handleClick, isClickable,
   } = useWSStatus();
 
   return (
@@ -27,9 +27,9 @@ const WebSocketStatus = memo((): JSX.Element => {
       {...canvasStyles.wsStatus.container}
       backgroundColor={color}
       onClick={handleClick}
-      cursor={isDisconnected ? 'pointer' : 'default'}
+      cursor={isClickable ? 'pointer' : 'default'}
       _hover={{
-        opacity: isDisconnected ? 0.8 : 1,
+        opacity: isClickable ? 0.8 : 1,
       }}
     >
       <MemoizedStatusContent textKey={textKey} />

--- a/src/renderer/src/components/electron/input-subtitle.tsx
+++ b/src/renderer/src/components/electron/input-subtitle.tsx
@@ -16,6 +16,20 @@ import { useInputSubtitle } from '@/hooks/electron/use-input-subtitle';
 import { useDraggable } from '@/hooks/electron/use-draggable';
 import { inputSubtitleStyles } from './electron-style';
 import { useMode } from '@/context/mode-context';
+import { useMood } from '@/context/mood-context';
+
+function getMoodPresentation(score: number) {
+  if (score >= 90) {
+    return { emoji: '😊', label: 'excited' };
+  }
+  if (score >= 80) {
+    return { emoji: '🙂', label: 'normal' };
+  }
+  if (score >= 60) {
+    return { emoji: '😔', label: 'low' };
+  }
+  return { emoji: '😶', label: 'silent' };
+}
 
 export function InputSubtitle() {
   const {
@@ -34,7 +48,10 @@ export function InputSubtitle() {
   } = useInputSubtitle();
 
   const { mode } = useMode();
+  const { moodScore } = useMood();
   const isPet = mode === 'pet';
+  const mood = getMoodPresentation(moodScore);
+  const moodDescription = `Mood: ${mood.label} (${moodScore})`;
 
   const {
     elementRef,
@@ -123,6 +140,21 @@ export function InputSubtitle() {
               <LuBell size={16} />
               <Text {...inputSubtitleStyles.statusText}>
                 {aiState}
+              </Text>
+              <Text
+                {...inputSubtitleStyles.statusText}
+                lineHeight="1"
+                title={moodDescription}
+                aria-label={moodDescription}
+              >
+                {mood.emoji}
+              </Text>
+              <Text
+                {...inputSubtitleStyles.statusText}
+                lineHeight="1"
+                aria-hidden="true"
+              >
+                {moodScore}
               </Text>
             </Flex>
 

--- a/src/renderer/src/components/footer/ai-state-indicator.tsx
+++ b/src/renderer/src/components/footer/ai-state-indicator.tsx
@@ -28,8 +28,6 @@ function AIStateIndicator(): JSX.Element {
   return (
     <Box
       {...styles.container}
-      width="auto"
-      maxWidth="160px"
       px="3"
       gap="2"
       title={moodDescription}
@@ -46,6 +44,7 @@ function AIStateIndicator(): JSX.Element {
         fontSize="11px"
         lineHeight="1"
         color="whiteAlpha.900"
+        fontVariantNumeric="tabular-nums"
         aria-hidden="true"
       >
         {moodScore}

--- a/src/renderer/src/components/footer/ai-state-indicator.tsx
+++ b/src/renderer/src/components/footer/ai-state-indicator.tsx
@@ -1,16 +1,55 @@
 import { Box, Text } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { useAiState } from '@/context/ai-state-context';
+import { useMood } from '@/context/mood-context';
 import { footerStyles } from './footer-styles';
+
+function getMoodPresentation(score: number) {
+  if (score >= 90) {
+    return { emoji: '😊', label: 'excited' };
+  }
+  if (score >= 80) {
+    return { emoji: '🙂', label: 'normal' };
+  }
+  if (score >= 60) {
+    return { emoji: '😔', label: 'low' };
+  }
+  return { emoji: '😶', label: 'silent' };
+}
 
 function AIStateIndicator(): JSX.Element {
   const { t } = useTranslation();
   const { aiState } = useAiState();
+  const { moodScore } = useMood();
   const styles = footerStyles.aiIndicator;
+  const mood = getMoodPresentation(moodScore);
+  const moodDescription = `Mood: ${mood.label} (${moodScore})`;
 
   return (
-    <Box {...styles.container}>
+    <Box
+      {...styles.container}
+      width="auto"
+      maxWidth="160px"
+      px="3"
+      gap="2"
+      title={moodDescription}
+    >
       <Text {...styles.text}>{t(`aiState.${aiState}`)}</Text>
+      <Text
+        fontSize="14px"
+        lineHeight="1"
+        aria-label={moodDescription}
+      >
+        {mood.emoji}
+      </Text>
+      <Text
+        fontSize="11px"
+        lineHeight="1"
+        color="whiteAlpha.900"
+        aria-hidden="true"
+      >
+        {moodScore}
+      </Text>
     </Box>
   );
 }

--- a/src/renderer/src/components/footer/footer-styles.tsx
+++ b/src/renderer/src/components/footer/footer-styles.tsx
@@ -1,7 +1,7 @@
 import { SystemStyleObject } from '@chakra-ui/react';
 
 interface FooterStyles {
-  container: (isCollapsed: boolean) => SystemStyleObject
+  container: (isCollapsed: boolean, hasAttachments: boolean) => SystemStyleObject
   toggleButton: SystemStyleObject
   actionButton: SystemStyleObject
   input: SystemStyleObject
@@ -18,13 +18,15 @@ export const footerStyles: {
   aiIndicator: AIIndicatorStyles
 } = {
   footer: {
-    container: (isCollapsed) => ({
+    container: (isCollapsed, hasAttachments) => ({
       bg: isCollapsed ? 'transparent' : 'gray.800',
       borderTopRadius: isCollapsed ? 'none' : 'lg',
       transform: isCollapsed ? 'translateY(calc(100% - 24px))' : 'translateY(0)',
       transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-      height: '100%',
+      height: 'auto',
+      minHeight: isCollapsed ? 'auto' : { base: '100px', md: '120px' },
       position: 'relative',
+      bottom: !isCollapsed && hasAttachments ? '5vh' : '0',
       overflow: isCollapsed ? 'visible' : 'hidden',
       pb: '4',
     }),

--- a/src/renderer/src/components/footer/footer-styles.tsx
+++ b/src/renderer/src/components/footer/footer-styles.tsx
@@ -26,7 +26,9 @@ export const footerStyles: {
       height: 'auto',
       minHeight: isCollapsed ? 'auto' : { base: '100px', md: '120px' },
       position: 'relative',
-      bottom: !isCollapsed && hasAttachments ? '5vh' : '0',
+      bottom: !isCollapsed && hasAttachments
+      ? 'clamp(1vh, calc(110px - 5vh), 1000vh)'
+      : '0px',
       overflow: isCollapsed ? 'visible' : 'hidden',
       pb: '4',
     }),

--- a/src/renderer/src/components/footer/footer-styles.tsx
+++ b/src/renderer/src/components/footer/footer-styles.tsx
@@ -91,7 +91,7 @@ export const footerStyles: {
     container: {
       bg: '#7C5CFF',
       color: 'white',
-      width: '110px',
+      width: '156px',
       height: '30px',
       borderRadius: '12px',
       display: 'flex',
@@ -99,12 +99,15 @@ export const footerStyles: {
       justifyContent: 'center',
       boxShadow: '0 2px 6px rgba(0,0,0,0.1)',
       overflow: 'hidden',
+      flexShrink: 0,
     },
     text: {
       fontSize: '12px',
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
+      minWidth: 0,
+      flex: 1,
     },
   },
 };

--- a/src/renderer/src/components/footer/footer.tsx
+++ b/src/renderer/src/components/footer/footer.tsx
@@ -2,7 +2,7 @@
 import {
   Box, Textarea, IconButton, HStack, Image,
 } from '@chakra-ui/react';
-import { BsMicFill, BsMicMuteFill, BsPaperclip } from 'react-icons/bs';
+import { BsMicFill, BsMicMuteFill, BsPaperclip, BsX } from 'react-icons/bs';
 import { IoHandRightSharp } from 'react-icons/io5';
 import { FiChevronDown } from 'react-icons/fi';
 import { memo, useRef } from 'react';
@@ -152,6 +152,7 @@ function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
     handleCompositionEnd,
     handleAttachFiles,
     attachedImages,
+    handleRemoveAttachment,
     handleInterrupt,
     handleMicToggle,
     micOn,
@@ -176,6 +177,7 @@ function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
               {attachedImages.map((image, index) => (
                 <Box
                   key={`${image.data}-${index}`}
+                  position="relative"
                   borderRadius="md"
                   overflow="hidden"
                   border="1px solid"
@@ -184,8 +186,26 @@ function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
                   <Image
                     src={image.data}
                     alt={t('footer.attachFile')}
-                    boxSize="64px"
+                    boxSize="128px"
                     objectFit="cover"
+                  />
+                  <IconButton
+                    aria-label={t('footer.removeAttachment')}
+                    icon={<BsX />}
+                    size="xs"          // 先用 xs 当基准
+                    w="18px"
+                    h="18px"
+                    minW="18px"        // IconButton 默认有 minW，不设会缩不下去
+                    p="0"
+                    fontSize="12px"    // 控制图标大小（icon 会吃到 fontSize）
+                    position="absolute"
+                    top="1"
+                    right="1"
+                    borderRadius="full"
+                    bg="blackAlpha.700"
+                    color="whiteAlpha.900"
+                    _hover={{ bg: 'blackAlpha.800' }}
+                    onClick={() => handleRemoveAttachment(index)}
                   />
                 </Box>
               ))}

--- a/src/renderer/src/components/footer/footer.tsx
+++ b/src/renderer/src/components/footer/footer.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/require-default-props */
 import {
-  Box, Textarea, IconButton, HStack,
+  Box, Textarea, IconButton, HStack, Image,
 } from '@chakra-ui/react';
 import { BsMicFill, BsMicMuteFill, BsPaperclip } from 'react-icons/bs';
 import { IoHandRightSharp } from 'react-icons/io5';
@@ -90,50 +90,52 @@ const MessageInput = memo(({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   return (
-    <InputGroup flex={1}>
-      <Box position="relative" width="100%">
-        <IconButton
-          aria-label="Attach file"
-          variant="ghost"
-          {...footerStyles.footer.attachButton}
-          onClick={() => fileInputRef.current?.click()}
-        >
-          <BsPaperclip size="24" />
-        </IconButton>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          multiple
-          style={{ display: 'none' }}
-          onChange={(event) => {
-            onAttachFiles(event.target.files);
-            event.target.value = '';
-          }}
-          aria-label={t('footer.attachFile')}
-        />
-        <Textarea
-          value={value}
-          onChange={onChange}
-          onKeyDown={onKeyDown}
-          onCompositionStart={onCompositionStart}
-          onCompositionEnd={onCompositionEnd}
-          placeholder={t('footer.typeYourMessage')}
-          {...footerStyles.footer.input}
-        />
-        {attachedCount > 0 && (
-          <Box
-            position="absolute"
-            top="2"
-            right="2"
-            fontSize="xs"
-            color="whiteAlpha.700"
+    <Box flex={1} minW="0" display="flex" flexDirection="column" gap="2">
+      <InputGroup>
+        <Box position="relative" width="100%">
+          <IconButton
+            aria-label="Attach file"
+            variant="ghost"
+            {...footerStyles.footer.attachButton}
+            onClick={() => fileInputRef.current?.click()}
           >
-            {t('footer.attachmentsCount', { count: attachedCount })}
-          </Box>
-        )}
-      </Box>
-    </InputGroup>
+            <BsPaperclip size="24" />
+          </IconButton>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            style={{ display: 'none' }}
+            onChange={(event) => {
+              onAttachFiles(event.target.files);
+              event.target.value = '';
+            }}
+            aria-label={t('footer.attachFile')}
+          />
+          <Textarea
+            value={value}
+            onChange={onChange}
+            onKeyDown={onKeyDown}
+            onCompositionStart={onCompositionStart}
+            onCompositionEnd={onCompositionEnd}
+            placeholder={t('footer.typeYourMessage')}
+            {...footerStyles.footer.input}
+          />
+          {attachedCount > 0 && (
+            <Box
+              position="absolute"
+              top="2"
+              right="2"
+              fontSize="xs"
+              color="whiteAlpha.700"
+            >
+              {t('footer.attachmentsCount', { count: attachedCount })}
+            </Box>
+          )}
+        </Box>
+      </InputGroup>
+    </Box>
   );
 });
 
@@ -141,6 +143,7 @@ MessageInput.displayName = 'MessageInput';
 
 // Main component
 function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
+  const { t } = useTranslation();
   const {
     inputValue,
     handleInputChange,
@@ -155,12 +158,42 @@ function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
   } = useFooter();
 
   return (
-    <Box {...footerStyles.footer.container(isCollapsed)}>
+    <Box {...footerStyles.footer.container(isCollapsed, attachedImages.length > 0)}>
       <ToggleButton isCollapsed={isCollapsed} onToggle={onToggle} />
 
       <Box pt="0" px="4">
-        <HStack width="100%" gap={4}>
-          <Box>
+        {attachedImages.length > 0 && (
+          <Box
+            width="100%"
+            minW="0"
+            bg="gray.700"
+            borderRadius="12px"
+            px="3"
+            py="2"
+            mb="3"
+          >
+            <HStack spacing="2" flexWrap="wrap">
+              {attachedImages.map((image, index) => (
+                <Box
+                  key={`${image.data}-${index}`}
+                  borderRadius="md"
+                  overflow="hidden"
+                  border="1px solid"
+                  borderColor="whiteAlpha.300"
+                >
+                  <Image
+                    src={image.data}
+                    alt={t('footer.attachFile')}
+                    boxSize="64px"
+                    objectFit="cover"
+                  />
+                </Box>
+              ))}
+            </HStack>
+          </Box>
+        )}
+        <HStack width="100%" gap={4} align="flex-start">
+          <Box flexShrink={0}>
             <Box mb="1.5">
               <AIStateIndicator />
             </Box>

--- a/src/renderer/src/components/footer/footer.tsx
+++ b/src/renderer/src/components/footer/footer.tsx
@@ -5,7 +5,7 @@ import {
 import { BsMicFill, BsMicMuteFill, BsPaperclip } from 'react-icons/bs';
 import { IoHandRightSharp } from 'react-icons/io5';
 import { FiChevronDown } from 'react-icons/fi';
-import { memo } from 'react';
+import { memo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { InputGroup } from '@/components/ui/input-group';
 import { footerStyles } from './footer-styles';
@@ -35,6 +35,8 @@ interface MessageInputProps {
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
   onCompositionStart: () => void
   onCompositionEnd: () => void
+  onAttachFiles: (files: FileList | null) => void
+  attachedCount: number
 }
 
 // Reusable components
@@ -81,8 +83,11 @@ const MessageInput = memo(({
   onKeyDown,
   onCompositionStart,
   onCompositionEnd,
+  onAttachFiles,
+  attachedCount,
 }: MessageInputProps) => {
   const { t } = useTranslation();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   return (
     <InputGroup flex={1}>
@@ -91,9 +96,22 @@ const MessageInput = memo(({
           aria-label="Attach file"
           variant="ghost"
           {...footerStyles.footer.attachButton}
+          onClick={() => fileInputRef.current?.click()}
         >
           <BsPaperclip size="24" />
         </IconButton>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          style={{ display: 'none' }}
+          onChange={(event) => {
+            onAttachFiles(event.target.files);
+            event.target.value = '';
+          }}
+          aria-label={t('footer.attachFile')}
+        />
         <Textarea
           value={value}
           onChange={onChange}
@@ -103,6 +121,17 @@ const MessageInput = memo(({
           placeholder={t('footer.typeYourMessage')}
           {...footerStyles.footer.input}
         />
+        {attachedCount > 0 && (
+          <Box
+            position="absolute"
+            top="2"
+            right="2"
+            fontSize="xs"
+            color="whiteAlpha.700"
+          >
+            {t('footer.attachmentsCount', { count: attachedCount })}
+          </Box>
+        )}
       </Box>
     </InputGroup>
   );
@@ -118,6 +147,8 @@ function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
     handleKeyPress,
     handleCompositionStart,
     handleCompositionEnd,
+    handleAttachFiles,
+    attachedImages,
     handleInterrupt,
     handleMicToggle,
     micOn,
@@ -146,6 +177,8 @@ function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
             onKeyDown={handleKeyPress}
             onCompositionStart={handleCompositionStart}
             onCompositionEnd={handleCompositionEnd}
+            onAttachFiles={handleAttachFiles}
+            attachedCount={attachedImages.length}
           />
         </HStack>
       </Box>

--- a/src/renderer/src/components/footer/footer.tsx
+++ b/src/renderer/src/components/footer/footer.tsx
@@ -1,13 +1,23 @@
 /* eslint-disable react/require-default-props */
 import {
-  Box, Textarea, IconButton, HStack, Image,
+  Box,
+  Textarea,
+  IconButton,
+  HStack,
+  Image,
 } from '@chakra-ui/react';
 import { BsMicFill, BsMicMuteFill, BsPaperclip, BsX } from 'react-icons/bs';
 import { IoHandRightSharp } from 'react-icons/io5';
 import { FiChevronDown } from 'react-icons/fi';
-import { memo, useRef } from 'react';
+import { memo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { InputGroup } from '@/components/ui/input-group';
+import {
+  DialogRoot,
+  DialogContent,
+  DialogCloseTrigger,
+  DialogBody,
+} from '@/components/ui/dialog';
 import { footerStyles } from './footer-styles';
 import AIStateIndicator from './ai-state-indicator';
 import { useFooter } from '@/hooks/footer/use-footer';
@@ -157,6 +167,7 @@ function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
     handleMicToggle,
     micOn,
   } = useFooter();
+  const [previewImage, setPreviewImage] = useState<string | null>(null);
 
   return (
     <Box {...footerStyles.footer.container(isCollapsed, attachedImages.length > 0)}>
@@ -182,6 +193,16 @@ function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
                   overflow="hidden"
                   border="1px solid"
                   borderColor="whiteAlpha.300"
+                  cursor="zoom-in"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setPreviewImage(image.data)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setPreviewImage(image.data);
+                    }
+                  }}
                 >
                   <Image
                     src={image.data}
@@ -205,7 +226,10 @@ function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
                     bg="blackAlpha.700"
                     color="whiteAlpha.900"
                     _hover={{ bg: 'blackAlpha.800' }}
-                    onClick={() => handleRemoveAttachment(index)}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleRemoveAttachment(index);
+                    }}
                   />
                 </Box>
               ))}
@@ -235,6 +259,29 @@ function Footer({ isCollapsed = false, onToggle }: FooterProps): JSX.Element {
           />
         </HStack>
       </Box>
+      <DialogRoot
+        open={Boolean(previewImage)}
+        onOpenChange={(details) => {
+          if (!details.open) {
+            setPreviewImage(null);
+          }
+        }}
+      >
+        <DialogContent bg="gray.900" maxW="80vw" w="fit-content">
+          <DialogCloseTrigger />
+          <DialogBody p="4">
+            {previewImage && (
+              <Image
+                src={previewImage}
+                alt={t('footer.previewAttachment')}
+                maxH="80vh"
+                maxW="80vw"
+                objectFit="contain"
+              />
+            )}
+          </DialogBody>
+        </DialogContent>
+      </DialogRoot>
     </Box>
   );
 }

--- a/src/renderer/src/components/sidebar/chat-history-panel.tsx
+++ b/src/renderer/src/components/sidebar/chat-history-panel.tsx
@@ -98,11 +98,12 @@ function ChatHistoryPanel(): JSX.Element {
                 } 
                 // Render Standard Chat Message (human or ai text)
                 const hasImages = msg.images && msg.images.length > 0;
+                const messageText = msg.content || (hasImages ? t('sidebar.imageMessage') : '');
                 return (
                   <ChatMessage
                     key={msg.id}
                     model={{
-                      message: msg.content || (hasImages ? t('sidebar.imageMessage') : ''),
+                      message: hasImages ? '' : messageText,
                       sentTime: msg.timestamp,
                       sender: msg.role === 'ai'
                         ? (msg.name || confName || 'AI')
@@ -136,24 +137,33 @@ function ChatHistoryPanel(): JSX.Element {
                       )}
                     </ChatAvatar>
                     {hasImages && (
-                      <Box mt="2" display="flex" flexWrap="wrap" gap="2">
-                        {msg.images?.map((image, index) => (
-                          <Box
-                            key={`${msg.id}-image-${index}`}
-                            borderRadius="md"
-                            overflow="hidden"
-                            border="1px solid"
-                            borderColor="whiteAlpha.300"
-                          >
-                            <Image
-                              src={image.data}
-                              alt={t('sidebar.imageMessage')}
-                              boxSize="128px"
-                              objectFit="cover"
-                            />
+                      <ChatMessage.CustomContent>
+                        <Box mt="2" display="flex" flexDirection="column" gap="2">
+                          <Box display="flex" flexWrap="wrap" gap="2">
+                            {msg.images?.map((image, index) => (
+                              <Box
+                                key={`${msg.id}-image-${index}`}
+                                borderRadius="md"
+                                overflow="hidden"
+                                border="1px solid"
+                                borderColor="whiteAlpha.300"
+                              >
+                                <Image
+                                  src={image.data}
+                                  alt={t('sidebar.imageMessage')}
+                                  boxSize="128px"
+                                  objectFit="cover"
+                              />
+                            </Box>
+                          ))}
                           </Box>
-                        ))}
-                      </Box>
+                          {msg.content && (
+                            <Text fontSize="sm" color="whiteAlpha.900" whiteSpace="pre-wrap">
+                              {msg.content}
+                            </Text>
+                          )}
+                        </Box>
+                      </ChatMessage.CustomContent>
                     )}
                   </ChatMessage>
                 );

--- a/src/renderer/src/components/sidebar/chat-history-panel.tsx
+++ b/src/renderer/src/components/sidebar/chat-history-panel.tsx
@@ -6,7 +6,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable react/require-default-props */
 import React, { useEffect } from 'react';
-import { Box, Spinner, Flex, Text, Icon } from '@chakra-ui/react';
+import { Box, Spinner, Flex, Text, Icon, Image } from '@chakra-ui/react';
 import { sidebarStyles, chatPanelStyles } from './sidebar-styles';
 import { MainContainer, ChatContainer, MessageList as ChatMessageList, Message as ChatMessage, Avatar as ChatAvatar } from '@chatscope/chat-ui-kit-react';
 import '@chatscope/chat-ui-kit-styles/dist/default/styles.min.css';
@@ -26,6 +26,7 @@ function ChatHistoryPanel(): JSX.Element {
   const userName = "Me";
 
   const validMessages = messages.filter((msg) => msg.content || // Keep messages with content
+     (msg.images && msg.images.length > 0) || // Keep messages with images
      (msg.type === 'tool_call_status' && msg.status === 'running') || // Keep running tools
      (msg.type === 'tool_call_status' && msg.status === 'completed') || // Keep completed tools
      (msg.type === 'tool_call_status' && msg.status === 'error'), // Keep error tools
@@ -96,11 +97,12 @@ function ChatHistoryPanel(): JSX.Element {
                   );
                 } 
                 // Render Standard Chat Message (human or ai text)
+                const hasImages = msg.images && msg.images.length > 0;
                 return (
                   <ChatMessage
                     key={msg.id}
                     model={{
-                      message: msg.content,
+                      message: msg.content || (hasImages ? t('sidebar.imageMessage') : ''),
                       sentTime: msg.timestamp,
                       sender: msg.role === 'ai'
                         ? (msg.name || confName || 'AI')
@@ -133,6 +135,26 @@ function ChatHistoryPanel(): JSX.Element {
                         userName[0].toUpperCase()
                       )}
                     </ChatAvatar>
+                    {hasImages && (
+                      <Box mt="2" display="flex" flexWrap="wrap" gap="2">
+                        {msg.images?.map((image, index) => (
+                          <Box
+                            key={`${msg.id}-image-${index}`}
+                            borderRadius="md"
+                            overflow="hidden"
+                            border="1px solid"
+                            borderColor="whiteAlpha.300"
+                          >
+                            <Image
+                              src={image.data}
+                              alt={t('sidebar.imageMessage')}
+                              boxSize="120px"
+                              objectFit="cover"
+                            />
+                          </Box>
+                        ))}
+                      </Box>
+                    )}
                   </ChatMessage>
                 );
               })

--- a/src/renderer/src/components/sidebar/chat-history-panel.tsx
+++ b/src/renderer/src/components/sidebar/chat-history-panel.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable import/order */
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable react/require-default-props */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Spinner, Flex, Text, Icon, Image } from '@chakra-ui/react';
 import { sidebarStyles, chatPanelStyles } from './sidebar-styles';
 import { MainContainer, ChatContainer, MessageList as ChatMessageList, Message as ChatMessage, Avatar as ChatAvatar } from '@chatscope/chat-ui-kit-react';
@@ -16,6 +16,12 @@ import { useConfig } from '@/context/character-config-context';
 import { useWebSocket } from '@/context/websocket-context';
 import { FaTools, FaCheck, FaTimes } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
+import {
+  DialogRoot,
+  DialogContent,
+  DialogCloseTrigger,
+  DialogBody,
+} from '@/components/ui/dialog';
 
 // Main component
 function ChatHistoryPanel(): JSX.Element {
@@ -24,6 +30,7 @@ function ChatHistoryPanel(): JSX.Element {
   const { confName } = useConfig();
   const { baseUrl } = useWebSocket();
   const userName = "Me";
+  const [previewImage, setPreviewImage] = useState<string | null>(null);
 
   const validMessages = messages.filter((msg) => msg.content || // Keep messages with content
      (msg.images && msg.images.length > 0) || // Keep messages with images
@@ -147,6 +154,16 @@ function ChatHistoryPanel(): JSX.Element {
                                 overflow="hidden"
                                 border="1px solid"
                                 borderColor="whiteAlpha.300"
+                                cursor="zoom-in"
+                                role="button"
+                                tabIndex={0}
+                                onClick={() => setPreviewImage(image.data)}
+                                onKeyDown={(event) => {
+                                  if (event.key === 'Enter' || event.key === ' ') {
+                                    event.preventDefault();
+                                    setPreviewImage(image.data);
+                                  }
+                                }}
                               >
                                 <Image
                                   src={image.data}
@@ -172,6 +189,29 @@ function ChatHistoryPanel(): JSX.Element {
           </ChatMessageList>
         </ChatContainer>
       </MainContainer>
+      <DialogRoot
+        open={Boolean(previewImage)}
+        onOpenChange={(details) => {
+          if (!details.open) {
+            setPreviewImage(null);
+          }
+        }}
+      >
+        <DialogContent bg="gray.900" maxW="80vw" w="fit-content">
+          <DialogCloseTrigger />
+          <DialogBody p="4">
+            {previewImage && (
+              <Image
+                src={previewImage}
+                alt={t('sidebar.previewImage')}
+                maxH="80vh"
+                maxW="80vw"
+                objectFit="contain"
+              />
+            )}
+          </DialogBody>
+        </DialogContent>
+      </DialogRoot>
     </Box>
   );
 }

--- a/src/renderer/src/components/sidebar/chat-history-panel.tsx
+++ b/src/renderer/src/components/sidebar/chat-history-panel.tsx
@@ -148,7 +148,7 @@ function ChatHistoryPanel(): JSX.Element {
                             <Image
                               src={image.data}
                               alt={t('sidebar.imageMessage')}
-                              boxSize="120px"
+                              boxSize="128px"
                               objectFit="cover"
                             />
                           </Box>

--- a/src/renderer/src/components/sidebar/sidebar-styles.tsx
+++ b/src/renderer/src/components/sidebar/sidebar-styles.tsx
@@ -499,10 +499,12 @@ export const chatPanelStyles = css`
     font-size: 0.95rem !important;
     line-height: 1.5 !important;
     margin-top: 4px !important;
+    white-space: pre-wrap !important;
   }
 
   .cs-message__text {
     padding: 8px 0 !important;
+    white-space: pre-wrap !important;
   }
 
   .cs-message--outgoing .cs-message__content {

--- a/src/renderer/src/context/character-config-context.tsx
+++ b/src/renderer/src/context/character-config-context.tsx
@@ -18,9 +18,11 @@ export interface ConfigFile {
 interface CharacterConfigState {
   confName: string;
   confUid: string;
+  asrEnabled: boolean;
   configFiles: ConfigFile[];
   setConfName: (name: string) => void;
   setConfUid: (uid: string) => void;
+  setAsrEnabled: (enabled: boolean) => void;
   setConfigFiles: (files: ConfigFile[]) => void;
   getFilenameByName: (name: string) => string | undefined;
 }
@@ -47,6 +49,7 @@ export const ConfigContext = createContext<CharacterConfigState | null>(null);
 export function CharacterConfigProvider({ children }: { children: React.ReactNode }) {
   const [confName, setConfName] = useState<string>(DEFAULT_CONFIG.confName);
   const [confUid, setConfUid] = useState<string>(DEFAULT_CONFIG.confUid);
+  const [asrEnabled, setAsrEnabled] = useState<boolean>(true);
   const [configFiles, setConfigFiles] = useState<ConfigFile[]>(DEFAULT_CONFIG.configFiles);
 
   const getFilenameByName = useCallback(
@@ -59,13 +62,15 @@ export function CharacterConfigProvider({ children }: { children: React.ReactNod
     () => ({
       confName,
       confUid,
+      asrEnabled,
       configFiles,
       setConfName,
       setConfUid,
+      setAsrEnabled,
       setConfigFiles,
       getFilenameByName,
     }),
-    [confName, confUid, configFiles, getFilenameByName],
+    [confName, confUid, asrEnabled, configFiles, getFilenameByName],
   );
 
   useEffect(() => {

--- a/src/renderer/src/context/chat-history-context.tsx
+++ b/src/renderer/src/context/chat-history-context.tsx
@@ -3,6 +3,7 @@ import {
   createContext, useContext, useState, useMemo, useCallback,
 } from 'react';
 import { Message } from '@/services/websocket-service';
+import { ImagePayload } from '@/types/media';
 import { HistoryInfo } from './websocket-context';
 
 /**
@@ -13,7 +14,7 @@ interface ChatHistoryState {
   messages: Message[]; // Use the unified Message type
   historyList: HistoryInfo[];
   currentHistoryUid: string | null;
-  appendHumanMessage: (content: string) => void;
+  appendHumanMessage: (content: string, images?: ImagePayload[]) => void;
   appendAIMessage: (content: string, name?: string, avatar?: string) => void;
   appendOrUpdateToolCallMessage: (toolMessageData: Partial<Message>) => void; // Accept partial data
   setMessages: (messages: Message[]) => void; // Use the unified Message type
@@ -65,13 +66,14 @@ export function ChatHistoryProvider({ children }: { children: React.ReactNode })
    * Append a human message to the chat history
    * @param content - Message content
    */
-  const appendHumanMessage = useCallback((content: string) => {
+  const appendHumanMessage = useCallback((content: string, images?: ImagePayload[]) => {
     const newMessage: Message = {
       id: Date.now().toString(),
       content,
       role: 'human',
       type: 'text', // Explicitly set type for human messages
       timestamp: new Date().toISOString(),
+      images,
     };
     setMessages((prevMessages) => [...prevMessages, newMessage]);
   }, []);

--- a/src/renderer/src/context/live2d-config-context.tsx
+++ b/src/renderer/src/context/live2d-config-context.tsx
@@ -73,6 +73,9 @@ export interface ModelInfo {
 
   /** Initial scale */
   initialScale?: number;
+
+  /** Render resolution scale (0.25-1.0), controlled by lab.toml */
+  renderScale?: number;
 }
 
 /**

--- a/src/renderer/src/context/live2d-config-context.tsx
+++ b/src/renderer/src/context/live2d-config-context.tsx
@@ -2,7 +2,6 @@ import {
   createContext, useContext, useState, useMemo,
 } from 'react';
 import { useLocalStorage } from '@/hooks/utils/use-local-storage';
-import { useConfig } from '@/context/character-config-context';
 
 /**
  * Model emotion mapping interface
@@ -82,6 +81,8 @@ interface Live2DConfigState {
   setModelInfo: (info: ModelInfo | undefined) => void;
   isLoading: boolean;
   setIsLoading: (loading: boolean) => void;
+  persistentAppearance?: string;
+  setPersistentAppearance: (appearance: string | undefined) => void;
 }
 
 /**
@@ -105,9 +106,8 @@ export const Live2DConfigContext = createContext<Live2DConfigState | null>(null)
  * @param {React.ReactNode} props.children - Child components
  */
 export function Live2DConfigProvider({ children }: { children: React.ReactNode }) {
-  const { confUid } = useConfig();
-
   const [isLoading, setIsLoading] = useState(DEFAULT_CONFIG.isLoading);
+  const [persistentAppearance, setPersistentAppearance] = useState<string | undefined>(undefined);
 
   const [modelInfo, setModelInfoState] = useLocalStorage<ModelInfo | undefined>(
     "modelInfo",
@@ -129,6 +129,7 @@ export function Live2DConfigProvider({ children }: { children: React.ReactNode }
     const finalScale = Number(info.kScale || 0.5) * 2;
     console.log("Setting model info with default scale:", finalScale);
 
+    setPersistentAppearance(undefined);
     setModelInfoState({
       ...info,
       kScale: finalScale,
@@ -149,8 +150,10 @@ export function Live2DConfigProvider({ children }: { children: React.ReactNode }
       setModelInfo,
       isLoading,
       setIsLoading,
+      persistentAppearance,
+      setPersistentAppearance,
     }),
-    [modelInfo, isLoading, setIsLoading],
+    [modelInfo, isLoading, setIsLoading, persistentAppearance],
   );
 
   return (

--- a/src/renderer/src/context/live2d-config-context.tsx
+++ b/src/renderer/src/context/live2d-config-context.tsx
@@ -56,6 +56,9 @@ export interface ModelInfo {
   /** Default emotion */
   defaultEmotion?: number | string;
 
+  /** Expression catalog from backend preset (name → file path) */
+  expressionCatalog?: Array<{ name: string; label: string; file: string }>;
+
   /** Emotion mapping configuration */
   emotionMap: EmotionMap;
 

--- a/src/renderer/src/context/mood-context.tsx
+++ b/src/renderer/src/context/mood-context.tsx
@@ -1,0 +1,44 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  ReactNode,
+} from 'react';
+
+interface MoodContextValue {
+  moodScore: number;
+  setMoodScore: (score: number) => void;
+}
+
+const DEFAULT_MOOD_SCORE = 80;
+
+const MoodContext = createContext<MoodContextValue | null>(null);
+
+export function MoodProvider({ children }: { children: ReactNode }) {
+  const [moodScore, setMoodScore] = useState<number>(DEFAULT_MOOD_SCORE);
+
+  const contextValue = useMemo(
+    () => ({
+      moodScore,
+      setMoodScore,
+    }),
+    [moodScore],
+  );
+
+  return (
+    <MoodContext.Provider value={contextValue}>
+      {children}
+    </MoodContext.Provider>
+  );
+}
+
+export function useMood(): MoodContextValue {
+  const context = useContext(MoodContext);
+
+  if (!context) {
+    throw new Error('useMood must be used within a MoodProvider');
+  }
+
+  return context;
+}

--- a/src/renderer/src/context/vad-context.tsx
+++ b/src/renderer/src/context/vad-context.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 import {
-  createContext, useContext, useRef, useCallback, useEffect, useReducer, useMemo,
+  createContext, useContext, useRef, useCallback, useEffect, useReducer, useMemo, useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MicVAD } from '@ricky0123/vad-web';
@@ -111,7 +111,7 @@ export function VADProvider({ children }: { children: React.ReactNode }) {
   const previousAiStateRef = useRef<AiState>('idle');
 
   // Persistent state management
-  const [micOn, setMicOn] = useLocalStorage('micOn', DEFAULT_VAD_STATE.micOn);
+  const [micOn, setMicOn] = useState(false);
   const autoStopMicRef = useRef(true);
   const [autoStopMic, setAutoStopMicState] = useLocalStorage(
     'autoStopMic',

--- a/src/renderer/src/context/websocket-context.tsx
+++ b/src/renderer/src/context/websocket-context.tsx
@@ -20,6 +20,7 @@ interface WebSocketContextProps {
   sendMessage: (message: object) => void;
   wsState: string;
   reconnect: () => void;
+  disconnect: () => void;
   wsUrl: string;
   setWsUrl: (url: string) => void;
   baseUrl: string;
@@ -30,6 +31,7 @@ export const WebSocketContext = React.createContext<WebSocketContextProps>({
   sendMessage: wsService.sendMessage.bind(wsService),
   wsState: 'CLOSED',
   reconnect: () => wsService.connect(DEFAULT_WS_URL),
+  disconnect: () => wsService.disconnect(),
   wsUrl: DEFAULT_WS_URL,
   setWsUrl: () => {},
   baseUrl: DEFAULT_BASE_URL,
@@ -59,6 +61,7 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
     sendMessage: wsService.sendMessage.bind(wsService),
     wsState: 'CLOSED',
     reconnect: () => wsService.connect(wsUrl),
+    disconnect: () => wsService.disconnect(),
     wsUrl,
     setWsUrl: handleSetWsUrl,
     baseUrl,

--- a/src/renderer/src/hooks/canvas/live2d-parameter-layer-controller.ts
+++ b/src/renderer/src/hooks/canvas/live2d-parameter-layer-controller.ts
@@ -1,0 +1,391 @@
+import { ModelInfo } from '@/context/live2d-config-context';
+
+export type ExpressionBlend = 'Add' | 'Multiply' | 'Overwrite';
+export type ExpressionSelector = string | number;
+
+interface ExpressionReference {
+  Name?: string;
+  File?: string;
+}
+
+interface ExpressionParameter {
+  Id?: string;
+  Value?: number;
+  Blend?: string;
+}
+
+interface ExpressionFile {
+  Parameters?: ExpressionParameter[];
+}
+
+interface Model3File {
+  FileReferences?: {
+    Expressions?: ExpressionReference[];
+  };
+}
+
+interface ResolvedExpressionReference {
+  expressionName: string;
+  fileUrl: string;
+}
+
+interface AppearanceOperation {
+  id: string;
+  value: number;
+  blend: ExpressionBlend;
+}
+
+export interface AppearancePatch {
+  expressionName: string;
+  operations: AppearanceOperation[];
+}
+
+interface PatchedModel {
+  _parameterLayerController?: {
+    controller: Live2DParameterLayerController;
+    originalUpdate: () => void;
+  };
+  _model?: {
+    addParameterValueById: (id: unknown, value: number, weight?: number) => void;
+    multiplyParameterValueById: (id: unknown, value: number, weight?: number) => void;
+    setParameterValueById: (id: unknown, value: number, weight?: number) => void;
+    update: () => void;
+  };
+  update: () => void;
+}
+
+const expressionCatalogCache = new Map<string, Promise<ResolvedExpressionReference[]>>();
+const appearancePatchCache = new Map<string, Promise<AppearancePatch | null>>();
+
+function normalizeBlend(blend: string | undefined): ExpressionBlend {
+  if (blend === 'Add' || blend === 'Multiply' || blend === 'Overwrite') {
+    return blend;
+  }
+  return 'Overwrite';
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+function resolveAssetUrl(modelUrl: string, relativePath: string): string {
+  return new URL(relativePath, modelUrl).toString();
+}
+
+async function getExpressionCatalog(modelUrl: string): Promise<ResolvedExpressionReference[]> {
+  const cached = expressionCatalogCache.get(modelUrl);
+  if (cached) {
+    return cached;
+  }
+
+  const loader = (async () => {
+    const model3 = await fetchJson<Model3File>(modelUrl);
+    return (model3.FileReferences?.Expressions ?? [])
+      .filter((expression): expression is ExpressionReference & { Name: string; File: string } =>
+        typeof expression.Name === 'string' && typeof expression.File === 'string')
+      .map((expression) => ({
+        expressionName: expression.Name,
+        fileUrl: resolveAssetUrl(modelUrl, expression.File),
+      }));
+  })();
+
+  expressionCatalogCache.set(modelUrl, loader);
+  return loader;
+}
+
+async function resolveExpressionReference(
+  modelInfo: ModelInfo,
+  selector: ExpressionSelector,
+): Promise<ResolvedExpressionReference | null> {
+  const catalog = await getExpressionCatalog(modelInfo.url);
+
+  if (typeof selector === 'number') {
+    return catalog[selector] ?? null;
+  }
+
+  return catalog.find((entry) => entry.expressionName === selector) ?? null;
+}
+
+export async function resolveAppearancePatch(
+  modelInfo: ModelInfo,
+  selector: ExpressionSelector,
+): Promise<AppearancePatch | null> {
+  const reference = await resolveExpressionReference(modelInfo, selector);
+  if (!reference) {
+    return null;
+  }
+
+  const cacheKey = `${modelInfo.url}::${reference.expressionName}`;
+  const cached = appearancePatchCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const loader = (async () => {
+    const expressionFile = await fetchJson<ExpressionFile>(reference.fileUrl);
+    return {
+      expressionName: reference.expressionName,
+      operations: (expressionFile.Parameters ?? [])
+        .filter((parameter): parameter is ExpressionParameter & { Id: string; Value: number } =>
+          typeof parameter.Id === 'string' && typeof parameter.Value === 'number')
+        .map((parameter) => ({
+          id: parameter.Id,
+          value: parameter.Value,
+          blend: normalizeBlend(parameter.Blend),
+        })),
+    };
+  })();
+
+  appearancePatchCache.set(cacheKey, loader);
+  return loader;
+}
+
+function applyPatchOperations(
+  model: PatchedModel,
+  lappAdapter: any,
+  patches: AppearancePatch[],
+): boolean {
+  if (!model._model || patches.length === 0) {
+    return false;
+  }
+
+  const idManager = lappAdapter.getIdManager?.();
+  if (!idManager?.getId) {
+    return false;
+  }
+
+  let applied = false;
+
+  patches.forEach((patch) => {
+    patch.operations.forEach((operation) => {
+      const parameterId = idManager.getId(operation.id);
+      switch (operation.blend) {
+        case 'Add':
+          model._model?.addParameterValueById(parameterId, operation.value, 1);
+          break;
+        case 'Multiply':
+          model._model?.multiplyParameterValueById(parameterId, operation.value, 1);
+          break;
+        case 'Overwrite':
+        default:
+          model._model?.setParameterValueById(parameterId, operation.value, 1);
+          break;
+      }
+      applied = true;
+    });
+  });
+
+  return applied;
+}
+
+class Live2DParameterLayerController {
+  private modelInfo?: ModelInfo;
+
+  private basePatches: AppearancePatch[] = [];
+
+  private baseLoadVersion = 0;
+
+  private transientRequestVersion = 0;
+
+  private requestedTransientSelector: ExpressionSelector | null = null;
+
+  private pendingTransientPatch: AppearancePatch | null | undefined = undefined;
+
+  private activeTransientPatch: AppearancePatch | null = null;
+
+  public syncBaseAppearance(modelInfo?: ModelInfo, persistentAppearance?: string): void {
+    const previousModelUrl = this.modelInfo?.url;
+    const nextModelUrl = modelInfo?.url;
+    const modelChanged = previousModelUrl !== nextModelUrl;
+
+    this.modelInfo = modelInfo;
+
+    if (modelChanged) {
+      this.basePatches = [];
+      this.activeTransientPatch = null;
+      if (this.requestedTransientSelector !== null) {
+        this.pendingTransientPatch = undefined;
+      }
+    }
+
+    const loadVersion = ++this.baseLoadVersion;
+
+    if (!modelInfo) {
+      this.basePatches = [];
+      return;
+    }
+
+    void this.loadBasePatches(loadVersion, modelInfo, persistentAppearance);
+
+    if (modelChanged && this.requestedTransientSelector !== null) {
+      void this.resolveTransientPatch(
+        this.transientRequestVersion,
+        this.requestedTransientSelector,
+        modelInfo,
+      );
+    }
+  }
+
+  public requestTransientExpression(selector: ExpressionSelector, logMessage?: string): void {
+    this.transientRequestVersion += 1;
+    this.requestedTransientSelector = selector;
+    this.pendingTransientPatch = undefined;
+
+    if (logMessage) {
+      console.log(logMessage);
+    }
+
+    if (!this.modelInfo) {
+      return;
+    }
+
+    void this.resolveTransientPatch(this.transientRequestVersion, selector, this.modelInfo);
+  }
+
+  public clearTransientExpression(logMessage?: string): void {
+    this.transientRequestVersion += 1;
+    this.requestedTransientSelector = null;
+    this.pendingTransientPatch = undefined;
+    this.activeTransientPatch = null;
+
+    if (logMessage) {
+      console.log(logMessage);
+    }
+  }
+
+  public installRunner(lappAdapter: any): boolean {
+    const model = lappAdapter?.getModel?.() as PatchedModel | null | undefined;
+    if (!model || !model._model || typeof model.update !== 'function') {
+      return false;
+    }
+
+    const existingRunner = model._parameterLayerController;
+    if (existingRunner?.controller === this) {
+      return true;
+    }
+
+    const originalUpdate = existingRunner?.originalUpdate ?? model.update.bind(model);
+    model._parameterLayerController = {
+      controller: this,
+      originalUpdate,
+    };
+
+    model.update = () => {
+      const runner = model._parameterLayerController;
+      runner?.originalUpdate();
+
+      // Keep the layering order stable: native Live2D update first, then base, then transient.
+      const appliedAnyPatch = this.applyLayers(model, lappAdapter);
+      if (appliedAnyPatch) {
+        model._model?.update();
+      }
+    };
+
+    return true;
+  }
+
+  private async loadBasePatches(
+    loadVersion: number,
+    modelInfo: ModelInfo,
+    persistentAppearance?: string,
+  ): Promise<void> {
+    try {
+      const selectors: ExpressionSelector[] = [];
+
+      if (modelInfo.defaultEmotion !== undefined) {
+        selectors.push(modelInfo.defaultEmotion);
+      }
+
+      if (persistentAppearance) {
+        selectors.push(persistentAppearance);
+      }
+
+      const patchMap = new Map<string, AppearancePatch>();
+      const resolvedPatches = await Promise.all(
+        selectors.map((selector) => resolveAppearancePatch(modelInfo, selector)),
+      );
+
+      if (loadVersion !== this.baseLoadVersion || this.modelInfo?.url !== modelInfo.url) {
+        return;
+      }
+
+      resolvedPatches.forEach((patch) => {
+        if (patch) {
+          patchMap.set(patch.expressionName, patch);
+        }
+      });
+
+      this.basePatches = Array.from(patchMap.values());
+    } catch (error) {
+      if (loadVersion !== this.baseLoadVersion) {
+        return;
+      }
+
+      console.warn('Failed to load Live2D base appearance patches:', error);
+      this.basePatches = [];
+    }
+  }
+
+  private async resolveTransientPatch(
+    requestVersion: number,
+    selector: ExpressionSelector,
+    modelInfo: ModelInfo,
+  ): Promise<void> {
+    try {
+      const patch = await resolveAppearancePatch(modelInfo, selector);
+      if (!this.isCurrentTransientRequest(requestVersion, selector, modelInfo.url)) {
+        return;
+      }
+
+      this.pendingTransientPatch = patch;
+    } catch (error) {
+      if (!this.isCurrentTransientRequest(requestVersion, selector, modelInfo.url)) {
+        return;
+      }
+
+      console.warn('Failed to resolve Live2D transient expression patch:', error);
+      this.pendingTransientPatch = null;
+    }
+  }
+
+  private isCurrentTransientRequest(
+    requestVersion: number,
+    selector: ExpressionSelector,
+    modelUrl: string,
+  ): boolean {
+    return requestVersion === this.transientRequestVersion
+      && this.requestedTransientSelector === selector
+      && this.modelInfo?.url === modelUrl;
+  }
+
+  private commitPendingTransientIfReady(): void {
+    if (this.requestedTransientSelector === null || this.pendingTransientPatch === undefined) {
+      return;
+    }
+
+    // Requests stay pending until a wrapped model update can safely commit them.
+    this.activeTransientPatch = this.pendingTransientPatch;
+    this.pendingTransientPatch = undefined;
+  }
+
+  private applyLayers(model: PatchedModel, lappAdapter: any): boolean {
+    this.commitPendingTransientIfReady();
+
+    const appliedBase = applyPatchOperations(model, lappAdapter, this.basePatches);
+    const appliedTransient = this.activeTransientPatch
+      ? applyPatchOperations(model, lappAdapter, [this.activeTransientPatch])
+      : false;
+
+    return appliedBase || appliedTransient;
+  }
+}
+
+const live2DParameterLayerController = new Live2DParameterLayerController();
+
+export function getLive2DParameterLayerController(): Live2DParameterLayerController {
+  return live2DParameterLayerController;
+}

--- a/src/renderer/src/hooks/canvas/live2d-parameter-layer-controller.ts
+++ b/src/renderer/src/hooks/canvas/live2d-parameter-layer-controller.ts
@@ -106,13 +106,23 @@ function resolveAssetUrl(modelUrl: string, relativePath: string): string {
   return new URL(relativePath, modelUrl).toString();
 }
 
-async function getExpressionCatalog(modelUrl: string): Promise<ResolvedExpressionReference[]> {
+async function getExpressionCatalog(modelInfo: ModelInfo): Promise<ResolvedExpressionReference[]> {
+  const modelUrl = modelInfo.url;
   const cached = expressionCatalogCache.get(modelUrl);
   if (cached) {
     return cached;
   }
 
   const loader = (async () => {
+    // Prefer backend-provided expressionCatalog (covers loose exp3 files not declared in model3.json)
+    if (modelInfo.expressionCatalog && modelInfo.expressionCatalog.length > 0) {
+      return modelInfo.expressionCatalog.map((entry) => ({
+        expressionName: entry.name,
+        fileUrl: resolveAssetUrl(modelUrl, entry.file),
+      }));
+    }
+
+    // Fallback: parse from model3.json FileReferences.Expressions
     const model3 = await fetchJson<Model3File>(modelUrl);
     return (model3.FileReferences?.Expressions ?? [])
       .filter((expression): expression is ExpressionReference & { Name: string; File: string } =>
@@ -131,7 +141,7 @@ async function resolveExpressionReference(
   modelInfo: ModelInfo,
   selector: ExpressionSelector,
 ): Promise<ResolvedExpressionReference | null> {
-  const catalog = await getExpressionCatalog(modelInfo.url);
+  const catalog = await getExpressionCatalog(modelInfo);
 
   if (typeof selector === 'number') {
     return catalog[selector] ?? null;

--- a/src/renderer/src/hooks/canvas/live2d-parameter-layer-controller.ts
+++ b/src/renderer/src/hooks/canvas/live2d-parameter-layer-controller.ts
@@ -57,6 +57,36 @@ interface PatchedModel {
 const expressionCatalogCache = new Map<string, Promise<ResolvedExpressionReference[]>>();
 const appearancePatchCache = new Map<string, Promise<AppearancePatch | null>>();
 
+// Keep persistent orientation/attention controls under mixer governance.
+// Appearance/expression patches can still shape face style, but should not own these channels.
+const MIXER_OWNED_PARAMETER_IDS = new Set([
+  'ParamAngleX',
+  'ParamAngleX2',
+  'ParamAngleX3',
+  'ParamAngleY',
+  'ParamAngleY2',
+  'ParamAngleY3',
+  'ParamAngleZ',
+  'ParamAngleZ2',
+  'ParamBodyAngleX',
+  'ParamBodyAngleY',
+  'ParamBodyAngleZ',
+  'bodyX',
+  'bodyX2',
+  'bodyX3',
+  'bodyY',
+  'bodyZ',
+  'bodyZ2',
+  'bodyZZ',
+  'bodyZZ2',
+  'ParamEyeBallX',
+  'ParamEyeBallY',
+]);
+
+function isMixerOwnedParameter(parameterId: string): boolean {
+  return MIXER_OWNED_PARAMETER_IDS.has(parameterId);
+}
+
 function normalizeBlend(blend: string | undefined): ExpressionBlend {
   if (blend === 'Add' || blend === 'Multiply' || blend === 'Overwrite') {
     return blend;
@@ -132,6 +162,7 @@ export async function resolveAppearancePatch(
       operations: (expressionFile.Parameters ?? [])
         .filter((parameter): parameter is ExpressionParameter & { Id: string; Value: number } =>
           typeof parameter.Id === 'string' && typeof parameter.Value === 'number')
+        .filter((parameter) => !isMixerOwnedParameter(parameter.Id))
         .map((parameter) => ({
           id: parameter.Id,
           value: parameter.Value,

--- a/src/renderer/src/hooks/canvas/live2d-pose-mixer-controller.ts
+++ b/src/renderer/src/hooks/canvas/live2d-pose-mixer-controller.ts
@@ -26,6 +26,21 @@ export type PoseLayerId = 'idle_layer' | 'speech_layer' | 'backend_pose_layer' |
 interface LayerState {
   weight: number;
   values: PoseValues;
+  weightTransition: WeightTransition | null;
+}
+
+interface WeightTransition {
+  fromWeight: number;
+  toWeight: number;
+  startTimeMs: number;
+  durationMs: number;
+}
+
+interface ScalarTransition {
+  fromValue: number;
+  toValue: number;
+  startTimeMs: number;
+  durationMs: number;
 }
 
 const DEFAULT_LAYER_WEIGHTS: Record<PoseLayerId, number> = {
@@ -46,8 +61,24 @@ const ORIENTATION_CHANNELS: LogicalChannel[] = [
   'gaze_y',
 ];
 
+const LAYER_WEIGHT_TRANSITION_MS = 480;
+const IDLE_MOUTH_BLEND_TRANSITION_MS = 320;
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
+}
+
+function easeInOutCubic(alpha: number): number {
+  if (alpha <= 0) {
+    return 0;
+  }
+  if (alpha >= 1) {
+    return 1;
+  }
+  if (alpha < 0.5) {
+    return 4 * alpha * alpha * alpha;
+  }
+  return 1 - ((-2 * alpha + 2) ** 3) / 2;
 }
 
 function sanitizeChannelValue(channel: LogicalChannel, value: number): number | null {
@@ -83,11 +114,15 @@ export class Live2DPoseMixerController {
 
   private idleMouthEnabled = true;
 
+  private idleMouthBlend = 1;
+
+  private idleMouthBlendTransition: ScalarTransition | null = null;
+
   private layers: Record<PoseLayerId, LayerState> = {
-    idle_layer: { weight: DEFAULT_LAYER_WEIGHTS.idle_layer, values: {} },
-    speech_layer: { weight: DEFAULT_LAYER_WEIGHTS.speech_layer, values: {} },
-    backend_pose_layer: { weight: DEFAULT_LAYER_WEIGHTS.backend_pose_layer, values: {} },
-    mouse_attention_layer: { weight: DEFAULT_LAYER_WEIGHTS.mouse_attention_layer, values: {} },
+    idle_layer: { weight: DEFAULT_LAYER_WEIGHTS.idle_layer, values: {}, weightTransition: null },
+    speech_layer: { weight: DEFAULT_LAYER_WEIGHTS.speech_layer, values: {}, weightTransition: null },
+    backend_pose_layer: { weight: DEFAULT_LAYER_WEIGHTS.backend_pose_layer, values: {}, weightTransition: null },
+    mouse_attention_layer: { weight: DEFAULT_LAYER_WEIGHTS.mouse_attention_layer, values: {}, weightTransition: null },
   };
 
   private readonly recordedIdleDriver = new RecordedIdleDriver((pose) => {
@@ -97,8 +132,9 @@ export class Live2DPoseMixerController {
   private lastFinalPose: PoseValues = {};
 
   private getMouseAttentionDragInput(): { x: number; y: number } {
+    const nowMs = performance.now();
     const layer = this.layers.mouse_attention_layer;
-    const layerWeight = layer?.weight;
+    const layerWeight = this.getResolvedLayerWeight('mouse_attention_layer', nowMs);
     if (!layer || typeof layerWeight !== 'number' || !Number.isFinite(layerWeight) || layerWeight <= 0) {
       return { x: 0, y: 0 };
     }
@@ -123,9 +159,14 @@ export class Live2DPoseMixerController {
    */
   public setLayerPose(layerId: PoseLayerId, values: PoseValues, weight?: number): void {
     this.layers[layerId] = {
-      weight: typeof weight === 'number' && Number.isFinite(weight) ? weight : this.layers[layerId].weight,
+      weight: this.layers[layerId].weight,
       values: { ...values },
+      weightTransition: this.layers[layerId].weightTransition,
     };
+    if (typeof weight === 'number' && Number.isFinite(weight)) {
+      this.transitionLayerWeight(layerId, weight);
+      return;
+    }
     this.refreshFinalPoseSnapshot();
   }
 
@@ -134,11 +175,15 @@ export class Live2DPoseMixerController {
    * Useful for backends that stream only changed channels.
    */
   public patchLayerPose(layerId: PoseLayerId, values: PoseValues, weight?: number): void {
-    const nextWeight = typeof weight === 'number' && Number.isFinite(weight) ? weight : this.layers[layerId].weight;
     this.layers[layerId] = {
-      weight: nextWeight,
+      weight: this.layers[layerId].weight,
       values: { ...this.layers[layerId].values, ...values },
+      weightTransition: this.layers[layerId].weightTransition,
     };
+    if (typeof weight === 'number' && Number.isFinite(weight)) {
+      this.transitionLayerWeight(layerId, weight);
+      return;
+    }
     this.refreshFinalPoseSnapshot();
   }
 
@@ -174,11 +219,7 @@ export class Live2DPoseMixerController {
     if (!Number.isFinite(weight) || weight < 0) {
       return;
     }
-    this.layers[layerId] = {
-      ...this.layers[layerId],
-      weight,
-    };
-    this.refreshFinalPoseSnapshot();
+    this.transitionLayerWeight(layerId, weight);
   }
 
   public patchLayerWeights(weights: Partial<Record<PoseLayerId, number>>): void {
@@ -188,10 +229,7 @@ export class Live2DPoseMixerController {
       if (typeof weight !== 'number' || !Number.isFinite(weight) || weight < 0) {
         return;
       }
-      this.layers[layerId] = {
-        ...this.layers[layerId],
-        weight,
-      };
+      this.transitionLayerWeight(layerId, weight, false);
       changed = true;
     });
 
@@ -202,10 +240,7 @@ export class Live2DPoseMixerController {
 
   public resetLayerWeights(): void {
     (Object.keys(DEFAULT_LAYER_WEIGHTS) as PoseLayerId[]).forEach((layerId) => {
-      this.layers[layerId] = {
-        ...this.layers[layerId],
-        weight: DEFAULT_LAYER_WEIGHTS[layerId],
-      };
+      this.transitionLayerWeight(layerId, DEFAULT_LAYER_WEIGHTS[layerId], false);
     });
     this.refreshFinalPoseSnapshot();
   }
@@ -245,8 +280,11 @@ export class Live2DPoseMixerController {
     const shouldEnableIdleMouth = this.idleState !== 'speaking';
     if (this.idleMouthEnabled !== shouldEnableIdleMouth) {
       this.idleMouthEnabled = shouldEnableIdleMouth;
-      this.refreshFinalPoseSnapshot();
+      this.transitionIdleMouthBlend(shouldEnableIdleMouth ? 1 : 0);
+      return;
     }
+
+    this.refreshFinalPoseSnapshot();
   }
 
   public setRecordedIdleBank(bank: IdleBankConfig | null): void {
@@ -270,22 +308,35 @@ export class Live2DPoseMixerController {
   }
 
   public getLayerStates(): Record<PoseLayerId, LayerState> {
+    const nowMs = performance.now();
     return {
       idle_layer: {
-        weight: this.layers.idle_layer.weight,
+        weight: this.getResolvedLayerWeight('idle_layer', nowMs),
         values: { ...this.layers.idle_layer.values },
+        weightTransition: this.layers.idle_layer.weightTransition
+          ? { ...this.layers.idle_layer.weightTransition }
+          : null,
       },
       speech_layer: {
-        weight: this.layers.speech_layer.weight,
+        weight: this.getResolvedLayerWeight('speech_layer', nowMs),
         values: { ...this.layers.speech_layer.values },
+        weightTransition: this.layers.speech_layer.weightTransition
+          ? { ...this.layers.speech_layer.weightTransition }
+          : null,
       },
       backend_pose_layer: {
-        weight: this.layers.backend_pose_layer.weight,
+        weight: this.getResolvedLayerWeight('backend_pose_layer', nowMs),
         values: { ...this.layers.backend_pose_layer.values },
+        weightTransition: this.layers.backend_pose_layer.weightTransition
+          ? { ...this.layers.backend_pose_layer.weightTransition }
+          : null,
       },
       mouse_attention_layer: {
-        weight: this.layers.mouse_attention_layer.weight,
+        weight: this.getResolvedLayerWeight('mouse_attention_layer', nowMs),
         values: { ...this.layers.mouse_attention_layer.values },
+        weightTransition: this.layers.mouse_attention_layer.weightTransition
+          ? { ...this.layers.mouse_attention_layer.weightTransition }
+          : null,
       },
     };
   }
@@ -299,6 +350,7 @@ export class Live2DPoseMixerController {
       modelUrl: this.modelUrl ?? null,
       idleState: this.idleState,
       idleMouthEnabled: this.idleMouthEnabled,
+      idleMouthBlend: this.getIdleMouthBlend(performance.now()),
       layers: this.getLayerStates(),
       finalPose: this.getFinalMixedPose(),
       profile: this.getProfile(),
@@ -393,30 +445,133 @@ export class Live2DPoseMixerController {
     w.Live2DPoseMixerDebug = debugApi;
   }
 
-  private getActiveLayers(): PoseLayer[] {
+  private transitionLayerWeight(layerId: PoseLayerId, targetWeight: number, refreshSnapshot: boolean = true): void {
+    const nowMs = performance.now();
+    const currentWeight = this.getResolvedLayerWeight(layerId, nowMs);
+    const normalizedTarget = Math.max(0, targetWeight);
+    this.layers[layerId] = {
+      ...this.layers[layerId],
+      weight: normalizedTarget,
+      weightTransition: Math.abs(currentWeight - normalizedTarget) <= 1e-4
+        ? null
+        : {
+          fromWeight: currentWeight,
+          toWeight: normalizedTarget,
+          startTimeMs: nowMs,
+          durationMs: LAYER_WEIGHT_TRANSITION_MS,
+        },
+    };
+
+    if (refreshSnapshot) {
+      this.refreshFinalPoseSnapshot();
+    }
+  }
+
+  private transitionIdleMouthBlend(targetValue: number): void {
+    const nowMs = performance.now();
+    const currentValue = this.getIdleMouthBlend(nowMs);
+    const normalizedTarget = clamp(targetValue, 0, 1);
+    this.idleMouthBlend = normalizedTarget;
+    this.idleMouthBlendTransition = Math.abs(currentValue - normalizedTarget) <= 1e-4
+      ? null
+      : {
+        fromValue: currentValue,
+        toValue: normalizedTarget,
+        startTimeMs: nowMs,
+        durationMs: IDLE_MOUTH_BLEND_TRANSITION_MS,
+      };
+    this.refreshFinalPoseSnapshot();
+  }
+
+  private getResolvedTransitionValue(
+    fromValue: number,
+    toValue: number,
+    startTimeMs: number,
+    durationMs: number,
+    nowMs: number,
+  ): number {
+    if (durationMs <= 0) {
+      return toValue;
+    }
+
+    const progress = clamp((nowMs - startTimeMs) / durationMs, 0, 1);
+    const alpha = easeInOutCubic(progress);
+    return fromValue + (toValue - fromValue) * alpha;
+  }
+
+  private getResolvedLayerWeight(layerId: PoseLayerId, nowMs: number = performance.now()): number {
+    const layer = this.layers[layerId];
+    const transition = layer.weightTransition;
+    if (!transition) {
+      return layer.weight;
+    }
+
+    const resolvedWeight = this.getResolvedTransitionValue(
+      transition.fromWeight,
+      transition.toWeight,
+      transition.startTimeMs,
+      transition.durationMs,
+      nowMs,
+    );
+
+    if (nowMs - transition.startTimeMs >= transition.durationMs) {
+      this.layers[layerId] = {
+        ...layer,
+        weightTransition: null,
+      };
+      return transition.toWeight;
+    }
+
+    return resolvedWeight;
+  }
+
+  private getIdleMouthBlend(nowMs: number = performance.now()): number {
+    const transition = this.idleMouthBlendTransition;
+    if (!transition) {
+      return this.idleMouthBlend;
+    }
+
+    const resolvedValue = this.getResolvedTransitionValue(
+      transition.fromValue,
+      transition.toValue,
+      transition.startTimeMs,
+      transition.durationMs,
+      nowMs,
+    );
+
+    if (nowMs - transition.startTimeMs >= transition.durationMs) {
+      this.idleMouthBlendTransition = null;
+      return transition.toValue;
+    }
+
+    return resolvedValue;
+  }
+
+  private getActiveLayers(nowMs: number = performance.now()): PoseLayer[] {
+    const idleMouthBlend = this.getIdleMouthBlend(nowMs);
     const layers: PoseLayer[] = [
       {
         id: 'idle_layer',
-        weight: this.layers.idle_layer.weight,
+        weight: this.getResolvedLayerWeight('idle_layer', nowMs),
         frame: isEmptyPose(this.layers.idle_layer.values) ? null : { values: this.layers.idle_layer.values },
         // 运行时策略：
         // - listening: 允许 recorded idle 的 mouth_open 参与
         // - speaking: 屏蔽 idle 的 mouth_open，嘴部交给语音链路（lip sync / speech）
-        mask: this.idleMouthEnabled ? undefined : { mouth_open: 0 },
+        mask: idleMouthBlend >= 0.999 ? undefined : { mouth_open: idleMouthBlend },
       },
       {
         id: 'speech_layer',
-        weight: this.layers.speech_layer.weight,
+        weight: this.getResolvedLayerWeight('speech_layer', nowMs),
         frame: isEmptyPose(this.layers.speech_layer.values) ? null : { values: this.layers.speech_layer.values },
       },
       {
         id: 'backend_pose_layer',
-        weight: this.layers.backend_pose_layer.weight,
+        weight: this.getResolvedLayerWeight('backend_pose_layer', nowMs),
         frame: isEmptyPose(this.layers.backend_pose_layer.values) ? null : { values: this.layers.backend_pose_layer.values },
       },
       {
         id: 'mouse_attention_layer',
-        weight: this.layers.mouse_attention_layer.weight,
+        weight: this.getResolvedLayerWeight('mouse_attention_layer', nowMs),
         frame: isEmptyPose(this.layers.mouse_attention_layer.values) ? null : { values: this.layers.mouse_attention_layer.values },
       },
     ];
@@ -425,7 +580,7 @@ export class Live2DPoseMixerController {
   }
 
   private refreshFinalPoseSnapshot(): void {
-    this.lastFinalPose = this.mixer.apply(this.getActiveLayers());
+    this.lastFinalPose = this.mixer.apply(this.getActiveLayers(performance.now()));
   }
 
   private applyParameterByMode(
@@ -453,10 +608,11 @@ export class Live2DPoseMixerController {
     this.refreshFinalPoseSnapshot();
     const finalPose: PoseValues = { ...this.lastFinalPose };
 
-    const isMouseOnlyMode = this.layers.mouse_attention_layer.weight > 0
-      && this.layers.idle_layer.weight <= 0
-      && this.layers.speech_layer.weight <= 0
-      && this.layers.backend_pose_layer.weight <= 0;
+    const nowMs = performance.now();
+    const isMouseOnlyMode = this.getResolvedLayerWeight('mouse_attention_layer', nowMs) > 0
+      && this.getResolvedLayerWeight('idle_layer', nowMs) <= 0
+      && this.getResolvedLayerWeight('speech_layer', nowMs) <= 0
+      && this.getResolvedLayerWeight('backend_pose_layer', nowMs) <= 0;
 
     if (isMouseOnlyMode) {
       ORIENTATION_CHANNELS.forEach((channel) => {

--- a/src/renderer/src/hooks/canvas/live2d-pose-mixer-controller.ts
+++ b/src/renderer/src/hooks/canvas/live2d-pose-mixer-controller.ts
@@ -685,12 +685,11 @@ export class Live2DPoseMixerController {
         frame: isEmptyPose(this.layers.idle_layer.values) ? null : { values: this.layers.idle_layer.values },
         // 运行时策略：
         // - listening: 允许 recorded idle 的嘴部曲线参与
-        // - speaking: 屏蔽 idle 的嘴部曲线，嘴部交给语音链路（lip sync / speech）
+        // - speaking: 仅屏蔽 idle 的 mouth_open，mouth_form 继续沿用 recorded idle
         mask: idleMouthBlend >= 0.999
           ? undefined
           : {
             mouth_open: idleMouthBlend,
-            mouth_form: idleMouthBlend,
           },
       },
       {

--- a/src/renderer/src/hooks/canvas/live2d-pose-mixer-controller.ts
+++ b/src/renderer/src/hooks/canvas/live2d-pose-mixer-controller.ts
@@ -1,0 +1,516 @@
+import {
+  getDefaultLive2DParameterProfile,
+  Live2DParameterApplyMode,
+  Live2DParameterProfile,
+} from '@/live2d/mixer/live2d-parameter-profile';
+import { LogicalChannel, PoseValues } from '@/live2d/mixer/logical-channels';
+import { IdleBankConfig, IdlePlayCommand, RecordedIdleDriver } from '@/live2d/mixer/recorded-idle-driver';
+import { Mixer, PoseLayer } from '@/live2d/mixer/pose-mixer';
+
+interface PatchedModel {
+  _poseMixerController?: {
+    controller: Live2DPoseMixerController;
+    originalUpdate: () => void;
+  };
+  setDragging?: (x: number, y: number) => void;
+  _model?: {
+    addParameterValueById: (id: unknown, value: number, weight?: number) => void;
+    setParameterValueById: (id: unknown, value: number, weight?: number) => void;
+    update: () => void;
+  };
+  update: () => void;
+}
+
+export type PoseLayerId = 'idle_layer' | 'speech_layer' | 'backend_pose_layer' | 'mouse_attention_layer';
+
+interface LayerState {
+  weight: number;
+  values: PoseValues;
+}
+
+const DEFAULT_LAYER_WEIGHTS: Record<PoseLayerId, number> = {
+  idle_layer: 1,
+  speech_layer: 1,
+  backend_pose_layer: 1,
+  mouse_attention_layer: 0.35,
+};
+
+const ORIENTATION_CHANNELS: LogicalChannel[] = [
+  'head_yaw',
+  'head_pitch',
+  'head_roll',
+  'body_yaw',
+  'body_pitch',
+  'body_roll',
+  'gaze_x',
+  'gaze_y',
+];
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function sanitizeChannelValue(channel: LogicalChannel, value: number): number | null {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  if (channel === 'mouth_open' || channel === 'eye_l_open' || channel === 'eye_r_open') {
+    return clamp(value, 0, 1);
+  }
+
+  if (channel === 'body_yaw' || channel === 'body_pitch' || channel === 'body_roll') {
+    // Recorded idle clips can exceed the nominal [-1, 1] range on body channels.
+    // Keep a wider safety band so large torso motion is preserved.
+    return clamp(value, -2, 2);
+  }
+
+  return clamp(value, -1, 1);
+}
+
+function isEmptyPose(values: PoseValues): boolean {
+  return Object.keys(values).length === 0;
+}
+
+export class Live2DPoseMixerController {
+  private readonly mixer = new Mixer({ mouthOpen: { preferLayerId: 'speech_layer' } });
+
+  private profile: Live2DParameterProfile = getDefaultLive2DParameterProfile();
+
+  private modelUrl?: string;
+
+  private idleState: string = 'listening';
+
+  private idleMouthEnabled = true;
+
+  private layers: Record<PoseLayerId, LayerState> = {
+    idle_layer: { weight: DEFAULT_LAYER_WEIGHTS.idle_layer, values: {} },
+    speech_layer: { weight: DEFAULT_LAYER_WEIGHTS.speech_layer, values: {} },
+    backend_pose_layer: { weight: DEFAULT_LAYER_WEIGHTS.backend_pose_layer, values: {} },
+    mouse_attention_layer: { weight: DEFAULT_LAYER_WEIGHTS.mouse_attention_layer, values: {} },
+  };
+
+  private readonly recordedIdleDriver = new RecordedIdleDriver((pose) => {
+    this.setIdlePose(pose);
+  });
+
+  private lastFinalPose: PoseValues = {};
+
+  private getMouseAttentionDragInput(): { x: number; y: number } {
+    const layer = this.layers.mouse_attention_layer;
+    const layerWeight = layer?.weight;
+    if (!layer || typeof layerWeight !== 'number' || !Number.isFinite(layerWeight) || layerWeight <= 0) {
+      return { x: 0, y: 0 };
+    }
+
+    const values = layer.values ?? {};
+    const rawX = [values.gaze_x, values.head_yaw, values.body_yaw]
+      .find((value) => typeof value === 'number' && Number.isFinite(value));
+    const rawY = [values.gaze_y, values.head_pitch]
+      .find((value) => typeof value === 'number' && Number.isFinite(value));
+
+    // Respect mixer weight amplitude for drag compatibility path:
+    // - weight = 0   => no mouse-attention drag
+    // - weight = 0.5 => half-strength drag
+    // - weight = 1   => full-strength drag
+    const x = typeof rawX === 'number' ? clamp(rawX * layerWeight, -1, 1) : 0;
+    const y = typeof rawY === 'number' ? clamp(rawY * layerWeight, -1, 1) : 0;
+    return { x, y };
+  }
+
+  /**
+   * Replace the entire pose for a layer (partial poses are allowed).
+   */
+  public setLayerPose(layerId: PoseLayerId, values: PoseValues, weight?: number): void {
+    this.layers[layerId] = {
+      weight: typeof weight === 'number' && Number.isFinite(weight) ? weight : this.layers[layerId].weight,
+      values: { ...values },
+    };
+    this.refreshFinalPoseSnapshot();
+  }
+
+  /**
+   * Merge a partial pose into an existing layer.
+   * Useful for backends that stream only changed channels.
+   */
+  public patchLayerPose(layerId: PoseLayerId, values: PoseValues, weight?: number): void {
+    const nextWeight = typeof weight === 'number' && Number.isFinite(weight) ? weight : this.layers[layerId].weight;
+    this.layers[layerId] = {
+      weight: nextWeight,
+      values: { ...this.layers[layerId].values, ...values },
+    };
+    this.refreshFinalPoseSnapshot();
+  }
+
+  public clearLayerPose(layerId: PoseLayerId): void {
+    this.layers[layerId] = {
+      ...this.layers[layerId],
+      values: {},
+    };
+    this.refreshFinalPoseSnapshot();
+  }
+
+  public setBackendPose(values: PoseValues, weight?: number): void {
+    this.setLayerPose('backend_pose_layer', values, weight);
+  }
+
+  public patchBackendPose(values: PoseValues, weight?: number): void {
+    this.patchLayerPose('backend_pose_layer', values, weight);
+  }
+
+  public clearBackendPose(): void {
+    this.clearLayerPose('backend_pose_layer');
+  }
+
+  public setMouseAttentionPose(values: PoseValues, weight?: number): void {
+    this.setLayerPose('mouse_attention_layer', values, weight);
+  }
+
+  public clearMouseAttention(): void {
+    this.clearLayerPose('mouse_attention_layer');
+  }
+
+  public setLayerWeight(layerId: PoseLayerId, weight: number): void {
+    if (!Number.isFinite(weight) || weight < 0) {
+      return;
+    }
+    this.layers[layerId] = {
+      ...this.layers[layerId],
+      weight,
+    };
+    this.refreshFinalPoseSnapshot();
+  }
+
+  public patchLayerWeights(weights: Partial<Record<PoseLayerId, number>>): void {
+    let changed = false;
+    (Object.keys(weights) as PoseLayerId[]).forEach((layerId) => {
+      const weight = weights[layerId];
+      if (typeof weight !== 'number' || !Number.isFinite(weight) || weight < 0) {
+        return;
+      }
+      this.layers[layerId] = {
+        ...this.layers[layerId],
+        weight,
+      };
+      changed = true;
+    });
+
+    if (changed) {
+      this.refreshFinalPoseSnapshot();
+    }
+  }
+
+  public resetLayerWeights(): void {
+    (Object.keys(DEFAULT_LAYER_WEIGHTS) as PoseLayerId[]).forEach((layerId) => {
+      this.layers[layerId] = {
+        ...this.layers[layerId],
+        weight: DEFAULT_LAYER_WEIGHTS[layerId],
+      };
+    });
+    this.refreshFinalPoseSnapshot();
+  }
+
+  public setSpeechMouthOpen(mouthOpen: number, weight?: number): void {
+    this.patchLayerPose('speech_layer', { mouth_open: mouthOpen }, weight);
+  }
+
+  public clearSpeech(): void {
+    this.clearLayerPose('speech_layer');
+  }
+
+  public setIdlePose(values: PoseValues, weight?: number): void {
+    this.setLayerPose('idle_layer', values, weight);
+  }
+
+  public clearIdlePose(): void {
+    this.clearLayerPose('idle_layer');
+  }
+
+  public setProfile(profile: Live2DParameterProfile): void {
+    this.profile = profile;
+    this.refreshFinalPoseSnapshot();
+  }
+
+  public setModelUrl(modelUrl?: string): void {
+    this.modelUrl = modelUrl;
+    this.recordedIdleDriver.setModelUrl(modelUrl);
+  }
+
+  public setIdleRuntimeState(state?: string | null): void {
+    const normalizedState = typeof state === 'string' ? state.trim().toLowerCase() : '';
+    if (normalizedState) {
+      this.idleState = normalizedState;
+    }
+
+    const shouldEnableIdleMouth = this.idleState !== 'speaking';
+    if (this.idleMouthEnabled !== shouldEnableIdleMouth) {
+      this.idleMouthEnabled = shouldEnableIdleMouth;
+      this.refreshFinalPoseSnapshot();
+    }
+  }
+
+  public setRecordedIdleBank(bank: IdleBankConfig | null): void {
+    this.recordedIdleDriver.setIdleBank(bank);
+  }
+
+  public clearRecordedIdleBank(): void {
+    this.recordedIdleDriver.clearIdleBank();
+  }
+
+  public playRecordedIdleClip(command: IdlePlayCommand | string | null | undefined): void {
+    this.recordedIdleDriver.playManualClip(command, performance.now() * 0.001);
+  }
+
+  public getRecordedIdleState() {
+    return this.recordedIdleDriver.getDebugState();
+  }
+
+  public getProfile(): Live2DParameterProfile {
+    return this.profile;
+  }
+
+  public getLayerStates(): Record<PoseLayerId, LayerState> {
+    return {
+      idle_layer: {
+        weight: this.layers.idle_layer.weight,
+        values: { ...this.layers.idle_layer.values },
+      },
+      speech_layer: {
+        weight: this.layers.speech_layer.weight,
+        values: { ...this.layers.speech_layer.values },
+      },
+      backend_pose_layer: {
+        weight: this.layers.backend_pose_layer.weight,
+        values: { ...this.layers.backend_pose_layer.values },
+      },
+      mouse_attention_layer: {
+        weight: this.layers.mouse_attention_layer.weight,
+        values: { ...this.layers.mouse_attention_layer.values },
+      },
+    };
+  }
+
+  public getFinalMixedPose(): PoseValues {
+    return { ...this.lastFinalPose };
+  }
+
+  public getDebugState() {
+    return {
+      modelUrl: this.modelUrl ?? null,
+      idleState: this.idleState,
+      idleMouthEnabled: this.idleMouthEnabled,
+      layers: this.getLayerStates(),
+      finalPose: this.getFinalMixedPose(),
+      profile: this.getProfile(),
+      recordedIdle: this.getRecordedIdleState(),
+    };
+  }
+
+  /**
+   * Install a post-update runner that applies the mixed pose via Live2D parameter IDs.
+   *
+   * Ordering note:
+   * - This is designed to coexist with the existing expression/motion system.
+   * - It runs after the underlying Live2D update (and any other wrappers that were installed earlier).
+   */
+  public installRunner(lappAdapter: any): boolean {
+    const model = lappAdapter?.getModel?.() as PatchedModel | null | undefined;
+    if (!model || !model._model || typeof model.update !== 'function') {
+      return false;
+    }
+
+    const existingRunner = model._poseMixerController;
+    if (existingRunner?.controller === this) {
+      return true;
+    }
+
+    const originalUpdate = existingRunner?.originalUpdate ?? model.update.bind(model);
+    model._poseMixerController = {
+      controller: this,
+      originalUpdate,
+    };
+
+    // Disable SDK built-in drag parameter injection; mouse attention is now a mixer layer.
+    const manager = (window as any).LAppLive2DManager?.getInstance?.();
+    manager?.setDragInputEnabled?.(false);
+
+    model.update = () => {
+      const runner = model._poseMixerController;
+      const dragInput = this.getMouseAttentionDragInput();
+      model.setDragging?.(dragInput.x, dragInput.y);
+      runner?.originalUpdate();
+      this.recordedIdleDriver.update(performance.now() * 0.001);
+
+      const appliedAnyPose = this.applyMixedPose(model, lappAdapter);
+      if (appliedAnyPose) {
+        model._model?.update();
+      }
+    };
+
+    return true;
+  }
+
+  public installDebugGlobals(): void {
+    const w = window as any;
+
+    const debugApi = {
+      setBackendPose: (pose: PoseValues, weight?: number) => this.setBackendPose(pose, weight),
+      patchBackendPose: (pose: PoseValues, weight?: number) => this.patchBackendPose(pose, weight),
+      clearBackendPose: () => this.clearBackendPose(),
+      setMouseAttentionPose: (pose: PoseValues, weight?: number) => this.setMouseAttentionPose(pose, weight),
+      clearMouseAttention: () => this.clearMouseAttention(),
+      setLayerWeight: (layerId: PoseLayerId, weight: number) => this.setLayerWeight(layerId, weight),
+      patchLayerWeights: (weights: Partial<Record<PoseLayerId, number>>) => this.patchLayerWeights(weights),
+      resetLayerWeights: () => this.resetLayerWeights(),
+      setSpeechMouthOpen: (value: number, weight?: number) => this.setSpeechMouthOpen(value, weight),
+      clearSpeech: () => this.clearSpeech(),
+      setIdlePose: (pose: PoseValues, weight?: number) => this.setIdlePose(pose, weight),
+      clearIdlePose: () => this.clearIdlePose(),
+      clearAllLayers: () => {
+        this.clearIdlePose();
+        this.clearSpeech();
+        this.clearBackendPose();
+        this.clearMouseAttention();
+      },
+      getLayers: () => this.getLayerStates(),
+      getFinalPose: () => this.getFinalMixedPose(),
+      getDebugState: () => this.getDebugState(),
+      getRecordedIdleState: () => this.getRecordedIdleState(),
+      setRecordedIdleBank: (bank: IdleBankConfig | null) => this.setRecordedIdleBank(bank),
+      clearRecordedIdleBank: () => this.clearRecordedIdleBank(),
+      playRecordedIdleClip: (command: IdlePlayCommand | string | null | undefined) => this.playRecordedIdleClip(command),
+      setIdleRuntimeState: (state?: string | null) => this.setIdleRuntimeState(state),
+      inspect: () => {
+        const debugState = this.getDebugState();
+        console.log('[Live2DPoseMixer] debug state', debugState);
+        return debugState;
+      },
+      getProfile: () => this.getProfile(),
+      setProfile: (profile: Live2DParameterProfile) => this.setProfile(profile),
+    };
+
+    w.Live2DPoseMixer = debugApi;
+    w.Live2DPoseMixerDebug = debugApi;
+  }
+
+  private getActiveLayers(): PoseLayer[] {
+    const layers: PoseLayer[] = [
+      {
+        id: 'idle_layer',
+        weight: this.layers.idle_layer.weight,
+        frame: isEmptyPose(this.layers.idle_layer.values) ? null : { values: this.layers.idle_layer.values },
+        // 运行时策略：
+        // - listening: 允许 recorded idle 的 mouth_open 参与
+        // - speaking: 屏蔽 idle 的 mouth_open，嘴部交给语音链路（lip sync / speech）
+        mask: this.idleMouthEnabled ? undefined : { mouth_open: 0 },
+      },
+      {
+        id: 'speech_layer',
+        weight: this.layers.speech_layer.weight,
+        frame: isEmptyPose(this.layers.speech_layer.values) ? null : { values: this.layers.speech_layer.values },
+      },
+      {
+        id: 'backend_pose_layer',
+        weight: this.layers.backend_pose_layer.weight,
+        frame: isEmptyPose(this.layers.backend_pose_layer.values) ? null : { values: this.layers.backend_pose_layer.values },
+      },
+      {
+        id: 'mouse_attention_layer',
+        weight: this.layers.mouse_attention_layer.weight,
+        frame: isEmptyPose(this.layers.mouse_attention_layer.values) ? null : { values: this.layers.mouse_attention_layer.values },
+      },
+    ];
+
+    return layers;
+  }
+
+  private refreshFinalPoseSnapshot(): void {
+    this.lastFinalPose = this.mixer.apply(this.getActiveLayers());
+  }
+
+  private applyParameterByMode(
+    model: PatchedModel,
+    parameterId: unknown,
+    value: number,
+    applyMode: Live2DParameterApplyMode,
+  ): void {
+    if (applyMode === 'add' && model._model?.addParameterValueById) {
+      model._model.addParameterValueById(parameterId, value, 1);
+      return;
+    }
+
+    model._model?.setParameterValueById(parameterId, value, 1);
+  }
+
+  private applyMixedPose(model: PatchedModel, lappAdapter: any): boolean {
+    const idManager = lappAdapter.getIdManager?.();
+    if (!idManager?.getId) {
+      return false;
+    }
+
+    // Mixer owns long-lived head/eye/body orientation channels.
+    // Future drag/mouse-attention/event layers should enter here as additional layers.
+    this.refreshFinalPoseSnapshot();
+    const finalPose: PoseValues = { ...this.lastFinalPose };
+
+    const isMouseOnlyMode = this.layers.mouse_attention_layer.weight > 0
+      && this.layers.idle_layer.weight <= 0
+      && this.layers.speech_layer.weight <= 0
+      && this.layers.backend_pose_layer.weight <= 0;
+
+    if (isMouseOnlyMode) {
+      ORIENTATION_CHANNELS.forEach((channel) => {
+        const value = finalPose[channel];
+        if (typeof value !== 'number' || !Number.isFinite(value)) {
+          // Mouse-only mode should still pin orientation channels to neutral 0
+          // when pointer data is temporarily unavailable, to avoid inheriting
+          // stale orientation from legacy motions/previous frames.
+          finalPose[channel] = 0;
+        }
+      });
+    }
+
+    const poseChannels = Object.keys(finalPose) as LogicalChannel[];
+    if (poseChannels.length === 0) {
+      return false;
+    }
+
+    let appliedAny = false;
+
+    poseChannels.forEach((channel) => {
+      const rawValue = finalPose[channel];
+      if (typeof rawValue !== 'number') {
+        return;
+      }
+
+      const sanitizedValue = sanitizeChannelValue(channel, rawValue);
+      if (sanitizedValue === null) {
+        return;
+      }
+
+      const targets = this.profile[channel];
+      if (!targets || targets.length === 0) {
+        return;
+      }
+
+      targets.forEach((target) => {
+        if (!target?.id || typeof target.scale !== 'number' || !Number.isFinite(target.scale)) {
+          return;
+        }
+
+        const parameterId = idManager.getId(target.id);
+        const applyMode = target.applyMode ?? 'set';
+        this.applyParameterByMode(model, parameterId, sanitizedValue * target.scale, applyMode);
+        appliedAny = true;
+      });
+    });
+
+    return appliedAny;
+  }
+}
+
+const live2DPoseMixerController = new Live2DPoseMixerController();
+
+export function getLive2DPoseMixerController(): Live2DPoseMixerController {
+  return live2DPoseMixerController;
+}

--- a/src/renderer/src/hooks/canvas/live2d-pose-mixer-controller.ts
+++ b/src/renderer/src/hooks/canvas/live2d-pose-mixer-controller.ts
@@ -61,8 +61,57 @@ const ORIENTATION_CHANNELS: LogicalChannel[] = [
   'gaze_y',
 ];
 
-const LAYER_WEIGHT_TRANSITION_MS = 480;
-const IDLE_MOUTH_BLEND_TRANSITION_MS = 320;
+const LAYER_WEIGHT_TRANSITION_MS = 960;
+const IDLE_MOUTH_BLEND_TRANSITION_MS = 640;
+const CHANNEL_RELEASE_EPSILON = 0.01;
+
+const CHANNEL_NEUTRAL_VALUES: Record<LogicalChannel, number> = {
+  head_yaw: 0,
+  head_pitch: 0,
+  head_roll: 0,
+  body_yaw: 0,
+  body_pitch: 0,
+  body_roll: 0,
+  gaze_x: 0,
+  gaze_y: 0,
+  eye_l_open: 1,
+  eye_r_open: 1,
+  brow_raise: 0,
+  mouth_open: 0,
+  mouth_form: 0,
+};
+
+const CHANNEL_TRANSITION_MS: Record<LogicalChannel, number> = {
+  head_yaw: 360,
+  head_pitch: 360,
+  head_roll: 360,
+  body_yaw: 520,
+  body_pitch: 520,
+  body_roll: 520,
+  gaze_x: 240,
+  gaze_y: 240,
+  eye_l_open: 220,
+  eye_r_open: 220,
+  brow_raise: 360,
+  mouth_open: 180,
+  mouth_form: 240,
+};
+
+const CHANNEL_RELEASE_MS: Record<LogicalChannel, number> = {
+  head_yaw: 440,
+  head_pitch: 440,
+  head_roll: 440,
+  body_yaw: 600,
+  body_pitch: 600,
+  body_roll: 600,
+  gaze_x: 300,
+  gaze_y: 300,
+  eye_l_open: 240,
+  eye_r_open: 240,
+  brow_raise: 360,
+  mouth_open: 220,
+  mouth_form: 300,
+};
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
@@ -142,6 +191,10 @@ export class Live2DPoseMixerController {
   });
 
   private lastFinalPose: PoseValues = {};
+
+  private lastAppliedPose: PoseValues = {};
+
+  private lastPoseSmoothingTimeMs: number | null = null;
 
   private getMouseAttentionDragInput(): { x: number; y: number } {
     const nowMs = performance.now();
@@ -279,7 +332,13 @@ export class Live2DPoseMixerController {
   }
 
   public setModelUrl(modelUrl?: string): void {
+    if (this.modelUrl === modelUrl) {
+      return;
+    }
+
     this.modelUrl = modelUrl;
+    this.lastAppliedPose = {};
+    this.lastPoseSmoothingTimeMs = null;
     this.recordedIdleDriver.setModelUrl(modelUrl);
   }
 
@@ -365,6 +424,7 @@ export class Live2DPoseMixerController {
       idleMouthBlend: this.getIdleMouthBlend(performance.now()),
       layers: this.getLayerStates(),
       finalPose: this.getFinalMixedPose(),
+      appliedPose: { ...this.lastAppliedPose },
       profile: this.getProfile(),
       recordedIdle: this.getRecordedIdleState(),
     };
@@ -511,6 +571,63 @@ export class Live2DPoseMixerController {
     return fromValue + (toValue - fromValue) * alpha;
   }
 
+  private getChannelStepAlpha(durationMs: number, dtMs: number): number {
+    if (durationMs <= 0) {
+      return 1;
+    }
+
+    const safeDtMs = clamp(dtMs, 1000 / 240, 120);
+    return 1 - Math.exp(-safeDtMs / durationMs);
+  }
+
+  private getSmoothedPose(targetPose: PoseValues, nowMs: number): PoseValues {
+    const previousPose = this.lastAppliedPose;
+    const previousTimeMs = this.lastPoseSmoothingTimeMs;
+    this.lastPoseSmoothingTimeMs = nowMs;
+
+    if (previousTimeMs === null) {
+      this.lastAppliedPose = { ...targetPose };
+      return { ...targetPose };
+    }
+
+    const dtMs = Math.max(nowMs - previousTimeMs, 0);
+    const nextPose: PoseValues = {};
+    const channels = new Set<LogicalChannel>([
+      ...(Object.keys(targetPose) as LogicalChannel[]),
+      ...(Object.keys(previousPose) as LogicalChannel[]),
+    ]);
+
+    channels.forEach((channel) => {
+      const targetValue = targetPose[channel];
+      const previousValue = previousPose[channel];
+
+      if (typeof targetValue === 'number' && Number.isFinite(targetValue)) {
+        if (typeof previousValue !== 'number' || !Number.isFinite(previousValue)) {
+          nextPose[channel] = targetValue;
+          return;
+        }
+
+        const alpha = this.getChannelStepAlpha(CHANNEL_TRANSITION_MS[channel], dtMs);
+        nextPose[channel] = previousValue + (targetValue - previousValue) * alpha;
+        return;
+      }
+
+      if (typeof previousValue !== 'number' || !Number.isFinite(previousValue)) {
+        return;
+      }
+
+      const neutralValue = CHANNEL_NEUTRAL_VALUES[channel];
+      const alpha = this.getChannelStepAlpha(CHANNEL_RELEASE_MS[channel], dtMs);
+      const releasedValue = previousValue + (neutralValue - previousValue) * alpha;
+      if (Math.abs(releasedValue - neutralValue) > CHANNEL_RELEASE_EPSILON) {
+        nextPose[channel] = releasedValue;
+      }
+    });
+
+    this.lastAppliedPose = nextPose;
+    return { ...nextPose };
+  }
+
   private getResolvedLayerWeight(layerId: PoseLayerId, nowMs: number = performance.now()): number {
     const layer = this.layers[layerId];
     const transition = layer.weightTransition;
@@ -643,7 +760,8 @@ export class Live2DPoseMixerController {
       });
     }
 
-    const poseChannels = Object.keys(finalPose) as LogicalChannel[];
+    const smoothedPose = this.getSmoothedPose(finalPose, nowMs);
+    const poseChannels = Object.keys(smoothedPose) as LogicalChannel[];
     if (poseChannels.length === 0) {
       return false;
     }
@@ -651,7 +769,7 @@ export class Live2DPoseMixerController {
     let appliedAny = false;
 
     poseChannels.forEach((channel) => {
-      const rawValue = finalPose[channel];
+      const rawValue = smoothedPose[channel];
       if (typeof rawValue !== 'number') {
         return;
       }

--- a/src/renderer/src/hooks/canvas/live2d-pose-mixer-controller.ts
+++ b/src/renderer/src/hooks/canvas/live2d-pose-mixer-controller.ts
@@ -90,6 +90,10 @@ function sanitizeChannelValue(channel: LogicalChannel, value: number): number | 
     return clamp(value, 0, 1);
   }
 
+  if (channel === 'mouth_form') {
+    return clamp(value, -1, 1);
+  }
+
   if (channel === 'body_yaw' || channel === 'body_pitch' || channel === 'body_roll') {
     // Recorded idle clips can exceed the nominal [-1, 1] range on body channels.
     // Keep a wider safety band so large torso motion is preserved.
@@ -104,7 +108,15 @@ function isEmptyPose(values: PoseValues): boolean {
 }
 
 export class Live2DPoseMixerController {
-  private readonly mixer = new Mixer({ mouthOpen: { preferLayerId: 'speech_layer' } });
+  private readonly mixer = new Mixer({
+    preferredChannels: {
+      eye_l_open: ['idle_layer'],
+      eye_r_open: ['idle_layer'],
+      brow_raise: ['idle_layer'],
+      mouth_open: ['speech_layer', 'idle_layer'],
+      mouth_form: ['speech_layer', 'idle_layer'],
+    },
+  });
 
   private profile: Live2DParameterProfile = getDefaultLive2DParameterProfile();
 
@@ -555,9 +567,14 @@ export class Live2DPoseMixerController {
         weight: this.getResolvedLayerWeight('idle_layer', nowMs),
         frame: isEmptyPose(this.layers.idle_layer.values) ? null : { values: this.layers.idle_layer.values },
         // 运行时策略：
-        // - listening: 允许 recorded idle 的 mouth_open 参与
-        // - speaking: 屏蔽 idle 的 mouth_open，嘴部交给语音链路（lip sync / speech）
-        mask: idleMouthBlend >= 0.999 ? undefined : { mouth_open: idleMouthBlend },
+        // - listening: 允许 recorded idle 的嘴部曲线参与
+        // - speaking: 屏蔽 idle 的嘴部曲线，嘴部交给语音链路（lip sync / speech）
+        mask: idleMouthBlend >= 0.999
+          ? undefined
+          : {
+            mouth_open: idleMouthBlend,
+            mouth_form: idleMouthBlend,
+          },
       },
       {
         id: 'speech_layer',

--- a/src/renderer/src/hooks/canvas/use-live2d-appearance.ts
+++ b/src/renderer/src/hooks/canvas/use-live2d-appearance.ts
@@ -1,237 +1,18 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { ModelInfo } from '@/context/live2d-config-context';
-
-type ExpressionBlend = 'Add' | 'Multiply' | 'Overwrite';
-
-interface ExpressionReference {
-  Name?: string;
-  File?: string;
-}
-
-interface ExpressionParameter {
-  Id?: string;
-  Value?: number;
-  Blend?: string;
-}
-
-interface ExpressionFile {
-  Parameters?: ExpressionParameter[];
-}
-
-interface Model3File {
-  FileReferences?: {
-    Expressions?: ExpressionReference[];
-  };
-}
-
-interface AppearanceOperation {
-  id: string;
-  value: number;
-  blend: ExpressionBlend;
-}
-
-interface AppearancePatch {
-  expressionName: string;
-  operations: AppearanceOperation[];
-}
-
-interface PatchedModel {
-  _appearancePatchController?: {
-    getPatches: () => AppearancePatch[];
-  };
-  _model?: {
-    addParameterValueById: (id: unknown, value: number, weight?: number) => void;
-    multiplyParameterValueById: (id: unknown, value: number, weight?: number) => void;
-    setParameterValueById: (id: unknown, value: number, weight?: number) => void;
-    update: () => void;
-  };
-  update: () => void;
-}
-
-const expressionFileMapCache = new Map<string, Promise<Map<string, string>>>();
-const appearancePatchCache = new Map<string, Promise<AppearancePatch>>();
-
-function normalizeBlend(blend: string | undefined): ExpressionBlend {
-  if (blend === 'Add' || blend === 'Multiply' || blend === 'Overwrite') {
-    return blend;
-  }
-  return 'Overwrite';
-}
-
-async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${url}: ${response.status}`);
-  }
-  return response.json() as Promise<T>;
-}
-
-function resolveAssetUrl(modelUrl: string, relativePath: string): string {
-  return new URL(relativePath, modelUrl).toString();
-}
-
-function getExpressionFileMap(modelUrl: string): Promise<Map<string, string>> {
-  const cached = expressionFileMapCache.get(modelUrl);
-  if (cached) {
-    return cached;
-  }
-
-  const loader = (async () => {
-    const model3 = await fetchJson<Model3File>(modelUrl);
-    const expressions = model3.FileReferences?.Expressions ?? [];
-    const expressionFileMap = new Map<string, string>();
-
-    expressions.forEach((expression) => {
-      if (expression.Name && expression.File) {
-        expressionFileMap.set(expression.Name, resolveAssetUrl(modelUrl, expression.File));
-      }
-    });
-
-    return expressionFileMap;
-  })();
-
-  expressionFileMapCache.set(modelUrl, loader);
-  return loader;
-}
-
-async function resolveAppearancePatch(
-  modelInfo: ModelInfo,
-  expressionName: string,
-): Promise<AppearancePatch | null> {
-  const expressionFileMap = await getExpressionFileMap(modelInfo.url);
-  const fileUrl = expressionFileMap.get(expressionName);
-  if (!fileUrl) {
-    return null;
-  }
-
-  const cacheKey = `${modelInfo.url}::${expressionName}`;
-  const cached = appearancePatchCache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
-
-  const loader = (async () => {
-    const expressionFile = await fetchJson<ExpressionFile>(fileUrl);
-    return {
-      expressionName,
-      operations: (expressionFile.Parameters ?? [])
-        .filter((parameter): parameter is ExpressionParameter & { Id: string; Value: number } =>
-          typeof parameter.Id === 'string' && typeof parameter.Value === 'number')
-        .map((parameter) => ({
-          id: parameter.Id,
-          value: parameter.Value,
-          blend: normalizeBlend(parameter.Blend),
-        })),
-    };
-  })();
-
-  appearancePatchCache.set(cacheKey, loader);
-  return loader;
-}
-
-function applyAppearancePatches(model: PatchedModel, lappAdapter: any, patches: AppearancePatch[]): void {
-  if (!model._model || patches.length === 0) {
-    return;
-  }
-
-  const idManager = lappAdapter.getIdManager?.();
-  if (!idManager?.getId) {
-    return;
-  }
-
-  patches.forEach((patch) => {
-    patch.operations.forEach((operation) => {
-      const parameterId = idManager.getId(operation.id);
-      switch (operation.blend) {
-        case 'Add':
-          model._model?.addParameterValueById(parameterId, operation.value, 1);
-          break;
-        case 'Multiply':
-          model._model?.multiplyParameterValueById(parameterId, operation.value, 1);
-          break;
-        case 'Overwrite':
-        default:
-          model._model?.setParameterValueById(parameterId, operation.value, 1);
-          break;
-      }
-    });
-  });
-
-  model._model.update();
-}
-
-function installAppearancePatchRunner(lappAdapter: any, getPatches: () => AppearancePatch[]): boolean {
-  const model = lappAdapter.getModel?.() as PatchedModel | null | undefined;
-  if (!model || !model._model || typeof model.update !== 'function') {
-    return false;
-  }
-
-  if (model._appearancePatchController) {
-    model._appearancePatchController.getPatches = getPatches;
-    return true;
-  }
-
-  const originalUpdate = model.update.bind(model);
-  model._appearancePatchController = { getPatches };
-  model.update = () => {
-    originalUpdate();
-    const patches = model._appearancePatchController?.getPatches() ?? [];
-    applyAppearancePatches(model, lappAdapter, patches);
-  };
-  return true;
-}
+import { getLive2DParameterLayerController } from '@/hooks/canvas/live2d-parameter-layer-controller';
 
 export const useLive2DAppearance = (
   modelInfo?: ModelInfo,
   persistentAppearance?: string,
 ) => {
-  const appearancePatchesRef = useRef<AppearancePatch[]>([]);
-
   useEffect(() => {
-    let cancelled = false;
-
-    const loadAppearancePatches = async () => {
-      if (!modelInfo) {
-        appearancePatchesRef.current = [];
-        return;
-      }
-
-      try {
-        const patches: AppearancePatch[] = [];
-
-        if (typeof modelInfo.defaultEmotion === 'string') {
-          const basePatch = await resolveAppearancePatch(modelInfo, modelInfo.defaultEmotion);
-          if (basePatch) {
-            patches.push(basePatch);
-          }
-        }
-
-        if (persistentAppearance) {
-          const persistentPatch = await resolveAppearancePatch(modelInfo, persistentAppearance);
-          if (persistentPatch) {
-            patches.push(persistentPatch);
-          }
-        }
-
-        if (!cancelled) {
-          appearancePatchesRef.current = patches;
-        }
-      } catch (error) {
-        console.warn('Failed to load Live2D appearance patches:', error);
-        if (!cancelled) {
-          appearancePatchesRef.current = [];
-        }
-      }
-    };
-
-    void loadAppearancePatches();
-
-    return () => {
-      cancelled = true;
-    };
+    const controller = getLive2DParameterLayerController();
+    controller.syncBaseAppearance(modelInfo, persistentAppearance);
   }, [modelInfo, persistentAppearance]);
 
   useEffect(() => {
+    const controller = getLive2DParameterLayerController();
     let frameId = 0;
     let cancelled = false;
 
@@ -241,7 +22,7 @@ export const useLive2DAppearance = (
       }
 
       const lappAdapter = (window as any).getLAppAdapter?.();
-      if (!lappAdapter || !installAppearancePatchRunner(lappAdapter, () => appearancePatchesRef.current)) {
+      if (!lappAdapter || !controller.installRunner(lappAdapter)) {
         frameId = window.requestAnimationFrame(ensureRunnerInstalled);
       }
     };

--- a/src/renderer/src/hooks/canvas/use-live2d-appearance.ts
+++ b/src/renderer/src/hooks/canvas/use-live2d-appearance.ts
@@ -1,0 +1,258 @@
+import { useEffect, useRef } from 'react';
+import { ModelInfo } from '@/context/live2d-config-context';
+
+type ExpressionBlend = 'Add' | 'Multiply' | 'Overwrite';
+
+interface ExpressionReference {
+  Name?: string;
+  File?: string;
+}
+
+interface ExpressionParameter {
+  Id?: string;
+  Value?: number;
+  Blend?: string;
+}
+
+interface ExpressionFile {
+  Parameters?: ExpressionParameter[];
+}
+
+interface Model3File {
+  FileReferences?: {
+    Expressions?: ExpressionReference[];
+  };
+}
+
+interface AppearanceOperation {
+  id: string;
+  value: number;
+  blend: ExpressionBlend;
+}
+
+interface AppearancePatch {
+  expressionName: string;
+  operations: AppearanceOperation[];
+}
+
+interface PatchedModel {
+  _appearancePatchController?: {
+    getPatches: () => AppearancePatch[];
+  };
+  _model?: {
+    addParameterValueById: (id: unknown, value: number, weight?: number) => void;
+    multiplyParameterValueById: (id: unknown, value: number, weight?: number) => void;
+    setParameterValueById: (id: unknown, value: number, weight?: number) => void;
+    update: () => void;
+  };
+  update: () => void;
+}
+
+const expressionFileMapCache = new Map<string, Promise<Map<string, string>>>();
+const appearancePatchCache = new Map<string, Promise<AppearancePatch>>();
+
+function normalizeBlend(blend: string | undefined): ExpressionBlend {
+  if (blend === 'Add' || blend === 'Multiply' || blend === 'Overwrite') {
+    return blend;
+  }
+  return 'Overwrite';
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+function resolveAssetUrl(modelUrl: string, relativePath: string): string {
+  return new URL(relativePath, modelUrl).toString();
+}
+
+function getExpressionFileMap(modelUrl: string): Promise<Map<string, string>> {
+  const cached = expressionFileMapCache.get(modelUrl);
+  if (cached) {
+    return cached;
+  }
+
+  const loader = (async () => {
+    const model3 = await fetchJson<Model3File>(modelUrl);
+    const expressions = model3.FileReferences?.Expressions ?? [];
+    const expressionFileMap = new Map<string, string>();
+
+    expressions.forEach((expression) => {
+      if (expression.Name && expression.File) {
+        expressionFileMap.set(expression.Name, resolveAssetUrl(modelUrl, expression.File));
+      }
+    });
+
+    return expressionFileMap;
+  })();
+
+  expressionFileMapCache.set(modelUrl, loader);
+  return loader;
+}
+
+async function resolveAppearancePatch(
+  modelInfo: ModelInfo,
+  expressionName: string,
+): Promise<AppearancePatch | null> {
+  const expressionFileMap = await getExpressionFileMap(modelInfo.url);
+  const fileUrl = expressionFileMap.get(expressionName);
+  if (!fileUrl) {
+    return null;
+  }
+
+  const cacheKey = `${modelInfo.url}::${expressionName}`;
+  const cached = appearancePatchCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const loader = (async () => {
+    const expressionFile = await fetchJson<ExpressionFile>(fileUrl);
+    return {
+      expressionName,
+      operations: (expressionFile.Parameters ?? [])
+        .filter((parameter): parameter is ExpressionParameter & { Id: string; Value: number } =>
+          typeof parameter.Id === 'string' && typeof parameter.Value === 'number')
+        .map((parameter) => ({
+          id: parameter.Id,
+          value: parameter.Value,
+          blend: normalizeBlend(parameter.Blend),
+        })),
+    };
+  })();
+
+  appearancePatchCache.set(cacheKey, loader);
+  return loader;
+}
+
+function applyAppearancePatches(model: PatchedModel, lappAdapter: any, patches: AppearancePatch[]): void {
+  if (!model._model || patches.length === 0) {
+    return;
+  }
+
+  const idManager = lappAdapter.getIdManager?.();
+  if (!idManager?.getId) {
+    return;
+  }
+
+  patches.forEach((patch) => {
+    patch.operations.forEach((operation) => {
+      const parameterId = idManager.getId(operation.id);
+      switch (operation.blend) {
+        case 'Add':
+          model._model?.addParameterValueById(parameterId, operation.value, 1);
+          break;
+        case 'Multiply':
+          model._model?.multiplyParameterValueById(parameterId, operation.value, 1);
+          break;
+        case 'Overwrite':
+        default:
+          model._model?.setParameterValueById(parameterId, operation.value, 1);
+          break;
+      }
+    });
+  });
+
+  model._model.update();
+}
+
+function installAppearancePatchRunner(lappAdapter: any, getPatches: () => AppearancePatch[]): boolean {
+  const model = lappAdapter.getModel?.() as PatchedModel | null | undefined;
+  if (!model || !model._model || typeof model.update !== 'function') {
+    return false;
+  }
+
+  if (model._appearancePatchController) {
+    model._appearancePatchController.getPatches = getPatches;
+    return true;
+  }
+
+  const originalUpdate = model.update.bind(model);
+  model._appearancePatchController = { getPatches };
+  model.update = () => {
+    originalUpdate();
+    const patches = model._appearancePatchController?.getPatches() ?? [];
+    applyAppearancePatches(model, lappAdapter, patches);
+  };
+  return true;
+}
+
+export const useLive2DAppearance = (
+  modelInfo?: ModelInfo,
+  persistentAppearance?: string,
+) => {
+  const appearancePatchesRef = useRef<AppearancePatch[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadAppearancePatches = async () => {
+      if (!modelInfo) {
+        appearancePatchesRef.current = [];
+        return;
+      }
+
+      try {
+        const patches: AppearancePatch[] = [];
+
+        if (typeof modelInfo.defaultEmotion === 'string') {
+          const basePatch = await resolveAppearancePatch(modelInfo, modelInfo.defaultEmotion);
+          if (basePatch) {
+            patches.push(basePatch);
+          }
+        }
+
+        if (persistentAppearance) {
+          const persistentPatch = await resolveAppearancePatch(modelInfo, persistentAppearance);
+          if (persistentPatch) {
+            patches.push(persistentPatch);
+          }
+        }
+
+        if (!cancelled) {
+          appearancePatchesRef.current = patches;
+        }
+      } catch (error) {
+        console.warn('Failed to load Live2D appearance patches:', error);
+        if (!cancelled) {
+          appearancePatchesRef.current = [];
+        }
+      }
+    };
+
+    void loadAppearancePatches();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [modelInfo, persistentAppearance]);
+
+  useEffect(() => {
+    let frameId = 0;
+    let cancelled = false;
+
+    const ensureRunnerInstalled = () => {
+      if (cancelled) {
+        return;
+      }
+
+      const lappAdapter = (window as any).getLAppAdapter?.();
+      if (!lappAdapter || !installAppearancePatchRunner(lappAdapter, () => appearancePatchesRef.current)) {
+        frameId = window.requestAnimationFrame(ensureRunnerInstalled);
+      }
+    };
+
+    ensureRunnerInstalled();
+
+    return () => {
+      cancelled = true;
+      if (frameId) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
+  }, [modelInfo?.url]);
+};

--- a/src/renderer/src/hooks/canvas/use-live2d-expression.ts
+++ b/src/renderer/src/hooks/canvas/use-live2d-expression.ts
@@ -1,83 +1,38 @@
 import { useCallback } from 'react';
 import { ModelInfo } from '@/context/live2d-config-context';
+import {
+  ExpressionSelector,
+  getLive2DParameterLayerController,
+} from '@/hooks/canvas/live2d-parameter-layer-controller';
 
 /**
- * Custom hook for handling Live2D model expressions
+ * Custom hook for handling transient Live2D expressions.
  */
 export const useLive2DExpression = () => {
   /**
-   * Set expression for Live2D model
-   * @param expressionValue - Expression name (string) or index (number)
-   * @param lappAdapter - LAppAdapter instance
-   * @param logMessage - Optional message to log on success
+   * Queue a transient expression patch.
+   * The adapter argument is kept for compatibility with the existing call sites.
    */
   const setExpression = useCallback((
-    expressionValue: string | number,
-    lappAdapter: any,
+    expressionValue: ExpressionSelector,
+    _lappAdapter?: any,
     logMessage?: string,
   ) => {
-    try {
-      if (typeof expressionValue === 'string') {
-        // Set expression by name
-        lappAdapter.setExpression(expressionValue);
-      } else if (typeof expressionValue === 'number') {
-        // Set expression by index
-        const expressionName = lappAdapter.getExpressionName(expressionValue);
-        if (expressionName) {
-          lappAdapter.setExpression(expressionName);
-        }
-      }
-      if (logMessage) {
-        console.log(logMessage);
-      }
-    } catch (error) {
-      console.error('Failed to set expression:', error);
-    }
+    getLive2DParameterLayerController().requestTransientExpression(expressionValue, logMessage);
   }, []);
 
   /**
-   * Reset expression to default
-   * @param lappAdapter - LAppAdapter instance
-   * @param modelInfo - Current model information
+   * Clear the transient expression layer so the model returns to its base appearance.
+   * The existing signature is preserved for compatibility.
    */
   const resetExpression = useCallback((
-    lappAdapter: any,
-    modelInfo?: ModelInfo,
+    _lappAdapter?: any,
+    _modelInfo?: ModelInfo,
   ) => {
-    if (!lappAdapter) return;
-
-    try {
-      // Check if model is loaded and has expressions
-      const model = lappAdapter.getModel();
-      if (!model || !model._modelSetting) {
-        console.log('Model or model settings not loaded yet, skipping expression reset');
-        return;
-      }
-
-      // If model has a default emotion defined, use it
-      if (modelInfo?.defaultEmotion !== undefined) {
-        setExpression(
-          modelInfo.defaultEmotion,
-          lappAdapter,
-          `Reset expression to default: ${modelInfo.defaultEmotion}`,
-        );
-      } else {
-        // Check if model has any expressions before trying to get the first one
-        const expressionCount = lappAdapter.getExpressionCount();
-        if (expressionCount > 0) {
-          const defaultExpressionName = lappAdapter.getExpressionName(0);
-          if (defaultExpressionName) {
-            setExpression(
-              defaultExpressionName,
-              lappAdapter,
-            );
-          }
-        }
-      }
-    } catch (error) {
-      console.log('Failed to reset expression:', error);
-    }
-  }, [setExpression]);
+    getLive2DParameterLayerController().clearTransientExpression(
+      'Cleared transient expression and returned to base appearance',
+    );
+  }, []);
 
   return {
     setExpression,

--- a/src/renderer/src/hooks/canvas/use-live2d-model.ts
+++ b/src/renderer/src/hooks/canvas/use-live2d-model.ts
@@ -11,6 +11,7 @@ import { LAppDelegate } from '../../../WebSDK/src/lappdelegate';
 import { LAppLive2DManager } from '../../../WebSDK/src/lapplive2dmanager';
 import { initializeLive2D } from '@cubismsdksamples/main';
 import { useMode } from '@/context/mode-context';
+import { getLive2DPoseMixerController } from '@/hooks/canvas/live2d-pose-mixer-controller';
 
 interface UseLive2DModelProps {
   modelInfo: ModelInfo | undefined;
@@ -22,7 +23,20 @@ interface Position {
   y: number;
 }
 
+interface MouseFollowPose {
+  head_yaw: number;
+  head_pitch: number;
+  head_roll: number;
+  body_yaw: number;
+  gaze_x: number;
+  gaze_y: number;
+}
+
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+const MOUSE_FOLLOW_START_DELAY_MS = 2000;
+const MOUSE_FOLLOW_SMOOTH_TIME_SECONDS = 0.28;
+const MOUSE_FOLLOW_MAX_SPEED_PER_SECOND = 2.3;
+const LOCAL_POINTER_PRIORITY_WINDOW_MS = 120;
 
 // Thresholds for tap vs drag detection
 const TAP_DURATION_THRESHOLD_MS = 200; // Max duration for a tap
@@ -104,6 +118,26 @@ export const useLive2DModel = ({
   const modelPositionRef = useRef<Position>({ x: 0, y: 0 });
   const prevModelUrlRef = useRef<string | null>(null);
   const isHoveringModelRef = useRef(false);
+  const mouseFollowEnableAtRef = useRef<number>(performance.now() + MOUSE_FOLLOW_START_DELAY_MS);
+  const mouseFollowPoseRef = useRef<MouseFollowPose>({
+    head_yaw: 0,
+    head_pitch: 0,
+    head_roll: 0,
+    body_yaw: 0,
+    gaze_x: 0,
+    gaze_y: 0,
+  });
+  const mouseFollowTargetPoseRef = useRef<MouseFollowPose>({
+    head_yaw: 0,
+    head_pitch: 0,
+    head_roll: 0,
+    body_yaw: 0,
+    gaze_x: 0,
+    gaze_y: 0,
+  });
+  const mouseFollowActiveRef = useRef<boolean>(false);
+  const mouseFollowLastUpdateMsRef = useRef<number | null>(null);
+  const localPointerPriorityUntilMsRef = useRef<number>(0);
   const electronApi = (window as any).electron;
 
   // --- State for Tap vs Drag ---
@@ -112,10 +146,42 @@ export const useLive2DModel = ({
   const isPotentialTapRef = useRef<boolean>(false); // Flag for ongoing potential tap/drag action
   // ---
 
+  const resetMouseFollowSmoothing = useCallback(() => {
+    mouseFollowPoseRef.current = {
+      head_yaw: 0,
+      head_pitch: 0,
+      head_roll: 0,
+      body_yaw: 0,
+      gaze_x: 0,
+      gaze_y: 0,
+    };
+    mouseFollowTargetPoseRef.current = {
+      head_yaw: 0,
+      head_pitch: 0,
+      head_roll: 0,
+      body_yaw: 0,
+      gaze_x: 0,
+      gaze_y: 0,
+    };
+    mouseFollowActiveRef.current = false;
+    mouseFollowLastUpdateMsRef.current = null;
+  }, []);
+
+  const clearMouseAttentionFollow = useCallback(() => {
+    resetMouseFollowSmoothing();
+    getLive2DPoseMixerController().clearMouseAttention();
+  }, [resetMouseFollowSmoothing]);
+
   useEffect(() => {
     const currentUrl = modelInfo?.url;
     const sdkScale = (window as any).LAppDefine?.CurrentKScale;
     const modelScale = modelInfo?.kScale !== undefined ? Number(modelInfo.kScale) : undefined;
+
+    if (!currentUrl) {
+      mouseFollowEnableAtRef.current = Number.POSITIVE_INFINITY;
+      clearMouseAttentionFollow();
+      return;
+    }
 
     const needsUpdate = currentUrl &&
                         (currentUrl !== prevModelUrlRef.current ||
@@ -123,6 +189,8 @@ export const useLive2DModel = ({
 
     if (needsUpdate) {
       prevModelUrlRef.current = currentUrl;
+      mouseFollowEnableAtRef.current = performance.now() + MOUSE_FOLLOW_START_DELAY_MS;
+      clearMouseAttentionFollow();
 
       try {
         const { baseUrl, modelDir, modelFileName } = parseModelUrl(currentUrl);
@@ -147,7 +215,7 @@ export const useLive2DModel = ({
         console.error('Error processing model URL:', error);
       }
     }
-  }, [modelInfo?.url, modelInfo?.kScale, modelInfo?.idleMotionGroupName]);
+  }, [modelInfo?.url, modelInfo?.kScale, modelInfo?.idleMotionGroupName, clearMouseAttentionFollow]);
 
   const getModelPosition = useCallback(() => {
     const adapter = (window as any).getLAppAdapter?.();
@@ -230,6 +298,12 @@ export const useLive2DModel = ({
     const scaledY = y * scaleY;
     const modelX = view._deviceToScreen.transformX(scaledX);
     const modelY = view._deviceToScreen.transformY(scaledY);
+    const viewX = typeof view.transformViewX === 'function'
+      ? view.transformViewX(scaledX)
+      : modelX;
+    const viewY = typeof view.transformViewY === 'function'
+      ? view.transformViewY(scaledY)
+      : modelY;
 
     return {
       adapter,
@@ -243,27 +317,111 @@ export const useLive2DModel = ({
       scaledY,
       modelX,
       modelY,
+      viewX,
+      viewY,
     };
   }, [canvasRef]);
 
+  const finalizeDragPosition = useCallback(() => {
+    const adapter = (window as any).getLAppAdapter?.();
+    if (adapter) {
+      const currentModel = adapter.getModel();
+      if (currentModel && currentModel._modelMatrix) {
+        const matrix = currentModel._modelMatrix.getArray();
+        const finalPos = { x: matrix[12], y: matrix[13] };
+        modelPositionRef.current = finalPos;
+        modelStartPos.current = finalPos;
+        setPosition(finalPos);
+      }
+    }
+    setIsDragging(false);
+  }, []);
+
   const updateMouseFollow = useCallback((clientX: number, clientY: number) => {
-    if (isDragging || isPotentialTapRef.current) {
+    if (performance.now() < mouseFollowEnableAtRef.current) {
+      clearMouseAttentionFollow();
+      return;
+    }
+
+    if (isDragging) {
+      clearMouseAttentionFollow();
       return;
     }
 
     const pointer = getPointerModelCoordinates(clientX, clientY);
     if (!pointer?.model?._modelMatrix) {
+      clearMouseAttentionFollow();
       return;
     }
 
-    const localX = pointer.model._modelMatrix.invertTransformX(pointer.modelX);
-    const localY = pointer.model._modelMatrix.invertTransformY(pointer.modelY);
+    // Keep mouse-attention input close to the legacy Cubism drag path:
+    // use view-space coordinates ([-1, 1] around visible area) rather than model-local matrix inversion.
+    const normalizedX = clamp(pointer.viewX, -1, 1);
+    const normalizedY = clamp(pointer.viewY, -1, 1);
+    mouseFollowTargetPoseRef.current = {
+      head_yaw: normalizedX,
+      head_pitch: normalizedY,
+      head_roll: normalizedX * normalizedY * -1,
+      body_yaw: normalizedX,
+      gaze_x: normalizedX,
+      gaze_y: normalizedY,
+    };
+    mouseFollowActiveRef.current = true;
+  }, [getPointerModelCoordinates, isDragging, clearMouseAttentionFollow]);
 
-    LAppLive2DManager.getInstance().onDrag(
-      clamp(localX, -1, 1),
-      clamp(localY, -1, 1),
-    );
-  }, [getPointerModelCoordinates, isDragging]);
+  useEffect(() => {
+    let rafId = 0;
+    let isDisposed = false;
+    const poseMixerController = getLive2DPoseMixerController();
+
+    const tick = (nowMs: number) => {
+      if (isDisposed) {
+        return;
+      }
+
+      if (
+        mouseFollowActiveRef.current
+        && !isDragging
+        && nowMs >= mouseFollowEnableAtRef.current
+      ) {
+        const lastUpdateMs = mouseFollowLastUpdateMsRef.current ?? (nowMs - 16.7);
+        const dtSeconds = clamp((nowMs - lastUpdateMs) * 0.001, 1 / 240, 0.1);
+        mouseFollowLastUpdateMsRef.current = nowMs;
+
+        const alpha = 1 - Math.exp(-dtSeconds / MOUSE_FOLLOW_SMOOTH_TIME_SECONDS);
+        const maxStep = MOUSE_FOLLOW_MAX_SPEED_PER_SECOND * dtSeconds;
+        const prev = mouseFollowPoseRef.current;
+        const target = mouseFollowTargetPoseRef.current;
+        const smooth = (from: number, to: number): number => {
+          const interpolated = from + (to - from) * alpha;
+          const delta = clamp(interpolated - from, -maxStep, maxStep);
+          return clamp(from + delta, -1, 1);
+        };
+
+        const next: MouseFollowPose = {
+          head_yaw: smooth(prev.head_yaw, target.head_yaw),
+          head_pitch: smooth(prev.head_pitch, target.head_pitch),
+          head_roll: smooth(prev.head_roll, target.head_roll),
+          body_yaw: smooth(prev.body_yaw, target.body_yaw),
+          gaze_x: smooth(prev.gaze_x, target.gaze_x),
+          gaze_y: smooth(prev.gaze_y, target.gaze_y),
+        };
+
+        mouseFollowPoseRef.current = next;
+        poseMixerController.setMouseAttentionPose(next);
+      } else {
+        mouseFollowLastUpdateMsRef.current = null;
+      }
+
+      rafId = window.requestAnimationFrame(tick);
+    };
+
+    rafId = window.requestAnimationFrame(tick);
+    return () => {
+      isDisposed = true;
+      window.cancelAnimationFrame(rafId);
+    };
+  }, [isDragging]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     const adapter = (window as any).getLAppAdapter?.();
@@ -375,6 +533,7 @@ export const useLive2DModel = ({
     // --- End Continue Drag Logic ---
 
     // --- Mouse Follow Logic (gaze + head + body follow mouse) ---
+    localPointerPriorityUntilMsRef.current = performance.now() + LOCAL_POINTER_PRIORITY_WINDOW_MS;
     updateMouseFollow(e.clientX, e.clientY);
     // --- End Mouse Follow Logic ---
 
@@ -403,17 +562,7 @@ export const useLive2DModel = ({
 
     if (isDragging) {
       // Finalize drag
-      setIsDragging(false);
-      if (adapter) {
-        const currentModel = adapter.getModel(); // Re-get model in case adapter changed
-        if (currentModel && currentModel._modelMatrix) {
-          const matrix = currentModel._modelMatrix.getArray();
-          const finalPos = { x: matrix[12], y: matrix[13] };
-          modelPositionRef.current = finalPos;
-          modelStartPos.current = finalPos; // Update base position for next potential drag
-          setPosition(finalPos);
-        }
-      }
+      finalizeDragPosition();
     } else if (isPotentialTapRef.current && adapter && model && view && canvasRef.current) {
       // --- Tap Motion Logic ---
       const timeElapsed = Date.now() - mouseDownTimeRef.current;
@@ -445,12 +594,15 @@ export const useLive2DModel = ({
 
     // Reset potential tap flag regardless of outcome
     isPotentialTapRef.current = false;
-  }, [isDragging, canvasRef, modelInfo]);
+  }, [isDragging, canvasRef, modelInfo, finalizeDragPosition]);
 
   const handleMouseLeave = useCallback(() => {
+    const hasGlobalCursorFollow = !isPet && Boolean(electronApi?.ipcRenderer?.invoke);
+    if (!hasGlobalCursorFollow) {
+      clearMouseAttentionFollow();
+    }
     if (isDragging) {
-      // If dragging and mouse leaves, treat it like a mouse up to end drag
-      handleMouseUp({} as React.MouseEvent); // Pass a dummy event or adjust handleMouseUp signature
+      finalizeDragPosition();
     }
 
     if (isPet || !electronApi?.ipcRenderer?.invoke) {
@@ -466,7 +618,24 @@ export const useLive2DModel = ({
       isHoveringModelRef.current = false;
       electronApi.ipcRenderer.send('update-component-hover', 'live2d-model', false);
     }
-  }, [isPet, isDragging, electronApi, handleMouseUp]);
+  }, [isPet, isDragging, electronApi, finalizeDragPosition, clearMouseAttentionFollow]);
+
+  useEffect(() => {
+    const handleGlobalPointerRelease = () => {
+      if (isDragging) {
+        finalizeDragPosition();
+      }
+      isPotentialTapRef.current = false;
+    };
+
+    window.addEventListener('mouseup', handleGlobalPointerRelease);
+    window.addEventListener('blur', handleGlobalPointerRelease);
+
+    return () => {
+      window.removeEventListener('mouseup', handleGlobalPointerRelease);
+      window.removeEventListener('blur', handleGlobalPointerRelease);
+    };
+  }, [isDragging, finalizeDragPosition]);
 
   useEffect(() => {
     if (isPet || !electronApi?.ipcRenderer?.invoke) {
@@ -477,6 +646,10 @@ export const useLive2DModel = ({
 
     const syncCursorFollow = async () => {
       if (isDisposed || isDragging || isPotentialTapRef.current) {
+        return;
+      }
+
+      if (performance.now() < localPointerPriorityUntilMsRef.current) {
         return;
       }
 

--- a/src/renderer/src/hooks/canvas/use-live2d-model.ts
+++ b/src/renderer/src/hooks/canvas/use-live2d-model.ts
@@ -728,7 +728,7 @@ export const useLive2DModel = ({
 
     const intervalId = window.setInterval(() => {
       void syncCursorFollow();
-    }, 33);
+    }, 100);
 
     return () => {
       isDisposed = true;

--- a/src/renderer/src/hooks/canvas/use-live2d-model.ts
+++ b/src/renderer/src/hooks/canvas/use-live2d-model.ts
@@ -125,7 +125,13 @@ export const useLive2DModel = ({
         const { baseUrl, modelDir, modelFileName } = parseModelUrl(currentUrl);
 
         if (baseUrl && modelDir) {
-          updateModelConfig(baseUrl, modelDir, modelFileName, Number(modelInfo.kScale));
+          updateModelConfig(
+            baseUrl,
+            modelDir,
+            modelFileName,
+            Number(modelInfo.kScale),
+            modelInfo.idleMotionGroupName,
+          );
 
           setTimeout(() => {
             if ((window as any).LAppLive2DManager?.releaseInstance) {
@@ -138,7 +144,7 @@ export const useLive2DModel = ({
         console.error('Error processing model URL:', error);
       }
     }
-  }, [modelInfo?.url, modelInfo?.kScale]);
+  }, [modelInfo?.url, modelInfo?.kScale, modelInfo?.idleMotionGroupName]);
 
   const getModelPosition = useCallback(() => {
     const adapter = (window as any).getLAppAdapter?.();

--- a/src/renderer/src/hooks/canvas/use-live2d-model.ts
+++ b/src/renderer/src/hooks/canvas/use-live2d-model.ts
@@ -8,6 +8,7 @@ import { useEffect, useRef, useCallback, useState, RefObject } from "react";
 import { ModelInfo } from "@/context/live2d-config-context";
 import { updateModelConfig } from '../../../WebSDK/src/lappdefine';
 import { LAppDelegate } from '../../../WebSDK/src/lappdelegate';
+import { LAppLive2DManager } from '../../../WebSDK/src/lapplive2dmanager';
 import { initializeLive2D } from '@cubismsdksamples/main';
 import { useMode } from '@/context/mode-context';
 
@@ -20,6 +21,8 @@ interface Position {
   x: number;
   y: number;
 }
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
 // Thresholds for tap vs drag detection
 const TAP_DURATION_THRESHOLD_MS = 200; // Max duration for a tap
@@ -208,6 +211,60 @@ export const useLive2DModel = ({
     return { x, y };
   }, [getCanvasScale]);
 
+  const getPointerModelCoordinates = useCallback((clientX: number, clientY: number) => {
+    const adapter = (window as any).getLAppAdapter?.();
+    const view = LAppDelegate.getInstance().getView();
+    const model = adapter?.getModel();
+    const canvas = canvasRef.current;
+
+    if (!view || !model || !canvas) {
+      return null;
+    }
+
+    const rect = canvas.getBoundingClientRect();
+    const x = clientX - rect.left;
+    const y = clientY - rect.top;
+    const scaleX = canvas.clientWidth ? canvas.width / canvas.clientWidth : 1;
+    const scaleY = canvas.clientHeight ? canvas.height / canvas.clientHeight : 1;
+    const scaledX = x * scaleX;
+    const scaledY = y * scaleY;
+    const modelX = view._deviceToScreen.transformX(scaledX);
+    const modelY = view._deviceToScreen.transformY(scaledY);
+
+    return {
+      adapter,
+      view,
+      model,
+      canvas,
+      rect,
+      x,
+      y,
+      scaledX,
+      scaledY,
+      modelX,
+      modelY,
+    };
+  }, [canvasRef]);
+
+  const updateMouseFollow = useCallback((clientX: number, clientY: number) => {
+    if (isDragging || isPotentialTapRef.current) {
+      return;
+    }
+
+    const pointer = getPointerModelCoordinates(clientX, clientY);
+    if (!pointer?.model?._modelMatrix) {
+      return;
+    }
+
+    const localX = pointer.model._modelMatrix.invertTransformX(pointer.modelX);
+    const localY = pointer.model._modelMatrix.invertTransformY(pointer.modelY);
+
+    LAppLive2DManager.getInstance().onDrag(
+      clamp(localX, -1, 1),
+      clamp(localY, -1, 1),
+    );
+  }, [getPointerModelCoordinates, isDragging]);
+
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     const adapter = (window as any).getLAppAdapter?.();
     if (!adapter || !canvasRef.current) return;
@@ -317,19 +374,19 @@ export const useLive2DModel = ({
     }
     // --- End Continue Drag Logic ---
 
+    // --- Mouse Follow Logic (gaze + head + body follow mouse) ---
+    updateMouseFollow(e.clientX, e.clientY);
+    // --- End Mouse Follow Logic ---
+
     // --- Pet Hover Logic (Unchanged) ---
     if (isPet && !isDragging && !isPotentialTapRef.current && electronApi && adapter && view && model && canvasRef.current) {
-      const canvas = canvasRef.current;
-      const rect = canvas.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-      const scale = canvas.width / canvas.clientWidth;
-      const scaledX = x * scale;
-      const scaledY = y * scale;
-      const modelX = view._deviceToScreen.transformX(scaledX);
-      const modelY = view._deviceToScreen.transformY(scaledY);
+      const pointer = getPointerModelCoordinates(e.clientX, e.clientY);
+      if (!pointer) {
+        return;
+      }
 
-      const currentHitState = model.anyhitTest(modelX, modelY) !== null || model.isHitOnModel(modelX, modelY);
+      const currentHitState = model.anyhitTest(pointer.modelX, pointer.modelY) !== null
+        || model.isHitOnModel(pointer.modelX, pointer.modelY);
 
       if (currentHitState !== isHoveringModelRef.current) {
         isHoveringModelRef.current = currentHitState;
@@ -337,7 +394,7 @@ export const useLive2DModel = ({
       }
     }
     // --- End Pet Hover Logic ---
-  }, [isPet, isDragging, electronApi, canvasRef]);
+  }, [isPet, isDragging, electronApi, canvasRef, getPointerModelCoordinates, updateMouseFollow]);
 
   const handleMouseUp = useCallback((e: React.MouseEvent) => {
     const adapter = (window as any).getLAppAdapter?.();
@@ -395,6 +452,11 @@ export const useLive2DModel = ({
       // If dragging and mouse leaves, treat it like a mouse up to end drag
       handleMouseUp({} as React.MouseEvent); // Pass a dummy event or adjust handleMouseUp signature
     }
+
+    if (isPet || !electronApi?.ipcRenderer?.invoke) {
+      LAppLive2DManager.getInstance().onDrag(0.0, 0.0);
+    }
+
     // Reset potential tap if mouse leaves before mouse up
     if (isPotentialTapRef.current) {
       isPotentialTapRef.current = false;
@@ -405,6 +467,40 @@ export const useLive2DModel = ({
       electronApi.ipcRenderer.send('update-component-hover', 'live2d-model', false);
     }
   }, [isPet, isDragging, electronApi, handleMouseUp]);
+
+  useEffect(() => {
+    if (isPet || !electronApi?.ipcRenderer?.invoke) {
+      return undefined;
+    }
+
+    let isDisposed = false;
+
+    const syncCursorFollow = async () => {
+      if (isDisposed || isDragging || isPotentialTapRef.current) {
+        return;
+      }
+
+      try {
+        const cursorPoint = await electronApi.ipcRenderer.invoke('get-cursor-window-point');
+        if (!cursorPoint || isDisposed) {
+          return;
+        }
+
+        updateMouseFollow(cursorPoint.x, cursorPoint.y);
+      } catch (error) {
+        console.error('Failed to sync global cursor for Live2D follow:', error);
+      }
+    };
+
+    const intervalId = window.setInterval(() => {
+      void syncCursorFollow();
+    }, 33);
+
+    return () => {
+      isDisposed = true;
+      window.clearInterval(intervalId);
+    };
+  }, [isPet, isDragging, electronApi, updateMouseFollow]);
 
   useEffect(() => {
     if (!isPet && electronApi && isHoveringModelRef.current) {

--- a/src/renderer/src/hooks/canvas/use-live2d-model.ts
+++ b/src/renderer/src/hooks/canvas/use-live2d-model.ts
@@ -279,6 +279,62 @@ export const useLive2DModel = ({
     return { x, y };
   }, [getCanvasScale]);
 
+  const getModelScreenBounds = useCallback((model: any) => {
+    const drawableModel = model?._model;
+    const matrix = model?._modelMatrix?.getArray?.();
+    const drawableCount = drawableModel?.getDrawableCount?.();
+
+    if (!drawableModel || !matrix || !drawableCount) {
+      return null;
+    }
+
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxY = Number.NEGATIVE_INFINITY;
+
+    for (let i = 0; i < drawableCount; i += 1) {
+      if (drawableModel.getDrawableDynamicFlagIsVisible && !drawableModel.getDrawableDynamicFlagIsVisible(i)) {
+        continue;
+      }
+
+      const vertices = drawableModel.getDrawableVertices(i);
+      if (!vertices || vertices.length < 2) {
+        continue;
+      }
+
+      for (let j = 0; j < vertices.length; j += 2) {
+        const vx = vertices[j];
+        const vy = vertices[j + 1];
+        const screenX = vx * matrix[0] + vy * matrix[4] + matrix[12];
+        const screenY = vx * matrix[1] + vy * matrix[5] + matrix[13];
+
+        minX = Math.min(minX, screenX);
+        minY = Math.min(minY, screenY);
+        maxX = Math.max(maxX, screenX);
+        maxY = Math.max(maxY, screenY);
+      }
+    }
+
+    if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+      return null;
+    }
+
+    const width = Math.max(maxX - minX, 0.5);
+    const height = Math.max(maxY - minY, 0.5);
+
+    return {
+      minX,
+      minY,
+      maxX,
+      maxY,
+      centerX: (minX + maxX) * 0.5,
+      centerY: (minY + maxY) * 0.5,
+      halfWidth: width * 0.5,
+      halfHeight: height * 0.5,
+    };
+  }, []);
+
   const getPointerModelCoordinates = useCallback((clientX: number, clientY: number) => {
     const adapter = (window as any).getLAppAdapter?.();
     const view = LAppDelegate.getInstance().getView();
@@ -319,8 +375,9 @@ export const useLive2DModel = ({
       modelY,
       viewX,
       viewY,
+      screenBounds: getModelScreenBounds(model),
     };
-  }, [canvasRef]);
+  }, [canvasRef, getModelScreenBounds]);
 
   const finalizeDragPosition = useCallback(() => {
     const adapter = (window as any).getLAppAdapter?.();
@@ -354,10 +411,14 @@ export const useLive2DModel = ({
       return;
     }
 
-    // Keep mouse-attention input close to the legacy Cubism drag path:
-    // use view-space coordinates ([-1, 1] around visible area) rather than model-local matrix inversion.
-    const normalizedX = clamp(pointer.viewX, -1, 1);
-    const normalizedY = clamp(pointer.viewY, -1, 1);
+    // Drive mouse-attention relative to the model's current on-screen bounds,
+    // so pet-mode repositioning does not change the apparent look-at anchor.
+    const normalizedX = pointer.screenBounds
+      ? clamp((pointer.modelX - pointer.screenBounds.centerX) / pointer.screenBounds.halfWidth, -1, 1)
+      : clamp(pointer.viewX, -1, 1);
+    const normalizedY = pointer.screenBounds
+      ? clamp((pointer.modelY - pointer.screenBounds.centerY) / pointer.screenBounds.halfHeight, -1, 1)
+      : clamp(pointer.viewY, -1, 1);
     mouseFollowTargetPoseRef.current = {
       head_yaw: normalizedX,
       head_pitch: normalizedY,

--- a/src/renderer/src/hooks/canvas/use-live2d-pose-mixer.ts
+++ b/src/renderer/src/hooks/canvas/use-live2d-pose-mixer.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { getLive2DPoseMixerController } from '@/hooks/canvas/live2d-pose-mixer-controller';
+
+/**
+ * Installs the minimal pose/mixer skeleton into the Live2D update loop.
+ *
+ * This is intentionally small and coexists with existing expression/motion/lipsync logic.
+ */
+export const useLive2DPoseMixer = (modelUrl?: string) => {
+  useEffect(() => {
+    const controller = getLive2DPoseMixerController();
+    controller.setModelUrl(modelUrl);
+    controller.installDebugGlobals();
+
+    let frameId = 0;
+    let cancelled = false;
+
+    const ensureRunnerInstalled = () => {
+      if (cancelled) {
+        return;
+      }
+
+      const lappAdapter = (window as any).getLAppAdapter?.();
+      if (!lappAdapter || !controller.installRunner(lappAdapter)) {
+        frameId = window.requestAnimationFrame(ensureRunnerInstalled);
+      }
+    };
+
+    ensureRunnerInstalled();
+
+    return () => {
+      cancelled = true;
+      if (frameId) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
+  }, [modelUrl]);
+};

--- a/src/renderer/src/hooks/canvas/use-live2d-resize.ts
+++ b/src/renderer/src/hooks/canvas/use-live2d-resize.ts
@@ -102,6 +102,13 @@ export const useLive2DResize = ({
     const currentScale = lastScaleRef.current;
     const diff = clampedTargetScale - currentScale;
 
+    if (Math.abs(diff) < 0.001) {
+      applyScale(clampedTargetScale);
+      lastScaleRef.current = clampedTargetScale;
+      isAnimatingRef.current = false;
+      return;
+    }
+
     const newScale = currentScale + diff * EASING_FACTOR;
     applyScale(newScale);
     lastScaleRef.current = newScale;
@@ -192,7 +199,8 @@ export const useLive2DResize = ({
         return;
       }
 
-      const dpr = window.devicePixelRatio || 1;
+      const renderScale = modelInfo?.renderScale ?? 1.0;
+      const dpr = Math.min(window.devicePixelRatio || 1, 2) * renderScale;
       canvas.width = Math.round(width * dpr);
       canvas.height = Math.round(height * dpr);
       canvas.style.width = `${width}px`;
@@ -209,7 +217,7 @@ export const useLive2DResize = ({
     } catch (error) {
       isResizingRef.current = false;
     }
-  }, [isPet, containerRef, modelInfo?.kScale, modelInfo?.initialXshift, modelInfo?.initialYshift, showSidebar, beforeResize, canvasRef]);
+  }, [isPet, containerRef, modelInfo?.kScale, modelInfo?.initialXshift, modelInfo?.initialYshift, modelInfo?.renderScale, showSidebar, beforeResize, canvasRef]);
 
   // Immediately respond to sidebar state changes
   useEffect(() => {

--- a/src/renderer/src/hooks/canvas/use-ws-status.ts
+++ b/src/renderer/src/hooks/canvas/use-ws-status.ts
@@ -5,17 +5,23 @@ interface WSStatusInfo {
   color: string
   textKey: string
   isDisconnected: boolean
+  isClickable: boolean
   handleClick: () => void
 }
 
 export const useWSStatus = () => {
-  const { wsState, reconnect } = useWebSocket();
+  const { wsState, reconnect, disconnect } = useWebSocket();
 
   const handleClick = useCallback(() => {
-    if (wsState !== 'OPEN' && wsState !== 'CONNECTING') {
+    if (wsState === 'OPEN') {
+      disconnect();
+      return;
+    }
+
+    if (wsState !== 'CONNECTING') {
       reconnect();
     }
-  }, [wsState, reconnect]);
+  }, [wsState, reconnect, disconnect]);
 
   const statusInfo = useMemo((): WSStatusInfo => {
     switch (wsState) {
@@ -24,6 +30,7 @@ export const useWSStatus = () => {
           color: 'green.500',
           textKey: 'wsStatus.connected',
           isDisconnected: false,
+          isClickable: true,
           handleClick,
         };
       case 'CONNECTING':
@@ -31,6 +38,7 @@ export const useWSStatus = () => {
           color: 'yellow.500',
           textKey: 'wsStatus.connecting',
           isDisconnected: false,
+          isClickable: false,
           handleClick,
         };
       default:
@@ -38,6 +46,7 @@ export const useWSStatus = () => {
           color: 'red.500',
           textKey: 'wsStatus.clickToReconnect',
           isDisconnected: true,
+          isClickable: true,
           handleClick,
         };
     }

--- a/src/renderer/src/hooks/footer/use-footer.ts
+++ b/src/renderer/src/hooks/footer/use-footer.ts
@@ -14,6 +14,8 @@ export const useFooter = () => {
     handleKeyPress: handleKey,
     handleCompositionStart,
     handleCompositionEnd,
+    handleAttachFiles,
+    attachedImages,
   } = useTextInput();
 
   const { interrupt } = useInterrupt();
@@ -49,6 +51,8 @@ export const useFooter = () => {
     handleKeyPress,
     handleCompositionStart,
     handleCompositionEnd,
+    handleAttachFiles,
+    attachedImages,
     handleInterrupt,
     handleMicToggle,
     micOn,

--- a/src/renderer/src/hooks/footer/use-footer.ts
+++ b/src/renderer/src/hooks/footer/use-footer.ts
@@ -16,6 +16,7 @@ export const useFooter = () => {
     handleCompositionEnd,
     handleAttachFiles,
     attachedImages,
+    handleRemoveAttachment,
   } = useTextInput();
 
   const { interrupt } = useInterrupt();
@@ -53,6 +54,7 @@ export const useFooter = () => {
     handleCompositionEnd,
     handleAttachFiles,
     attachedImages,
+    handleRemoveAttachment,
     handleInterrupt,
     handleMicToggle,
     micOn,

--- a/src/renderer/src/hooks/footer/use-text-input.tsx
+++ b/src/renderer/src/hooks/footer/use-text-input.tsx
@@ -105,6 +105,10 @@ export function useTextInput() {
   const handleCompositionStart = () => setIsComposing(true);
   const handleCompositionEnd = () => setIsComposing(false);
 
+  const handleRemoveAttachment = useCallback((indexToRemove: number) => {
+    setAttachedImages((prev) => prev.filter((_, index) => index !== indexToRemove));
+  }, []);
+
   return {
     inputText,
     setInputText: handleInputChange,
@@ -114,5 +118,6 @@ export function useTextInput() {
     handleCompositionStart,
     handleCompositionEnd,
     attachedImages,
+    handleRemoveAttachment,
   };
 }

--- a/src/renderer/src/hooks/footer/use-text-input.tsx
+++ b/src/renderer/src/hooks/footer/use-text-input.tsx
@@ -1,14 +1,18 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useWebSocket } from '@/context/websocket-context';
 import { useAiState } from '@/context/ai-state-context';
 import { useInterrupt } from '@/components/canvas/live2d';
 import { useChatHistory } from '@/context/chat-history-context';
 import { useVAD } from '@/context/vad-context';
-import { useMediaCapture } from '@/hooks/utils/use-media-capture';
+import { toaster } from '@/components/ui/toaster';
+import { useMediaCapture, ImageData } from '@/hooks/utils/use-media-capture';
 
 export function useTextInput() {
+  const { t } = useTranslation();
   const [inputText, setInputText] = useState('');
   const [isComposing, setIsComposing] = useState(false);
+  const [attachedImages, setAttachedImages] = useState<ImageData[]>([]);
   const wsContext = useWebSocket();
   const { aiState } = useAiState();
   const { interrupt } = useInterrupt();
@@ -20,15 +24,61 @@ export function useTextInput() {
     setInputText(e.target.value);
   };
 
+  const readFileAsDataUrl = useCallback((file: File) => new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  }), []);
+
+  const handleAttachFiles = useCallback(async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+
+    const newImages: ImageData[] = [];
+    for (const file of Array.from(files)) {
+      if (!file.type.startsWith('image/')) {
+        toaster.create({
+          title: t('error.unsupportedFileType'),
+          type: 'error',
+          duration: 2000,
+        });
+        continue;
+      }
+
+      try {
+        const dataUrl = await readFileAsDataUrl(file);
+        newImages.push({
+          source: 'upload',
+          data: dataUrl,
+          mime_type: file.type || 'image/*',
+        });
+      } catch (error) {
+        console.error('Failed to read attachment:', error);
+        toaster.create({
+          title: t('error.failedReadFile', { filename: file.name }),
+          type: 'error',
+          duration: 2000,
+        });
+      }
+    }
+
+    if (newImages.length > 0) {
+      setAttachedImages((prev) => [...prev, ...newImages]);
+    }
+  }, [readFileAsDataUrl, t]);
+
   const handleSend = async () => {
-    if (!inputText.trim() || !wsContext) return;
+    if (!wsContext) return;
+    if (!inputText.trim() && attachedImages.length === 0) return;
     if (aiState === 'thinking-speaking') {
       interrupt();
     }
 
-    const images = await captureAllMedia();
+    const images = [...(await captureAllMedia()), ...attachedImages];
 
-    appendHumanMessage(inputText.trim());
+    if (inputText.trim()) {
+      appendHumanMessage(inputText.trim());
+    }
     wsContext.sendMessage({
       type: 'text-input',
       text: inputText.trim(),
@@ -37,6 +87,7 @@ export function useTextInput() {
 
     if (autoStopMic) stopMic();
     setInputText('');
+    setAttachedImages([]);
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -55,8 +106,10 @@ export function useTextInput() {
     inputText,
     setInputText: handleInputChange,
     handleSend,
+    handleAttachFiles,
     handleKeyPress,
     handleCompositionStart,
     handleCompositionEnd,
+    attachedImages,
   };
 }

--- a/src/renderer/src/hooks/utils/use-audio-task.ts
+++ b/src/renderer/src/hooks/utils/use-audio-task.ts
@@ -66,7 +66,7 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
   const { setSubtitleText } = useSubtitle();
   const { appendResponse, appendAIMessage } = useChatHistory();
   const { sendMessage } = useWebSocket();
-  const { setExpression } = useLive2DExpression();
+  const { setExpression, resetExpression } = useLive2DExpression();
 
   // State refs to avoid stale closures
   const stateRef = useRef({
@@ -145,11 +145,15 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
     try {
       if (audioBase64) {
         if (expressions?.[0] !== undefined) {
-          setExpression(
-            expressions[0],
-            undefined,
-            `Queued transient expression: ${expressions[0]}`,
-          );
+          if (expressions[0] === '__neutral__') {
+            resetExpression();
+          } else {
+            setExpression(
+              expressions[0],
+              undefined,
+              `Queued transient expression: ${expressions[0]}`,
+            );
+          }
         }
 
         const audioDataUrl = `data:audio/wav;base64,${audioBase64}`;

--- a/src/renderer/src/hooks/utils/use-audio-task.ts
+++ b/src/renderer/src/hooks/utils/use-audio-task.ts
@@ -84,10 +84,13 @@ export const useAudioTask = () => {
 
     // Update display text
     if (displayText) {
-      appendText(displayText.text);
-      appendAI(displayText.text, displayText.name, displayText.avatar);
-      if (audioBase64) {
-        updateSubtitle(displayText.text);
+      const renderedText = displayText.text;
+      const isToolStatus = !audioBase64 && renderedText.includes('🔧');
+
+      appendText(renderedText);
+      appendAI(renderedText, displayText.name, displayText.avatar);
+      if (audioBase64 || isToolStatus) {
+        updateSubtitle(renderedText);
       }
       if (!forwarded) {
         sendMessage({

--- a/src/renderer/src/hooks/utils/use-audio-task.ts
+++ b/src/renderer/src/hooks/utils/use-audio-task.ts
@@ -24,10 +24,23 @@ interface AudioTaskOptions {
   forwarded?: boolean
 }
 
+interface UseAudioTaskOptions {
+  managePlaybackCompletion?: boolean
+}
+
+const TOOL_STATUS_ONLY_RE = /^\s*(?:<tool>\s*)?\[[^\]]+\]\s*(?:<\/tool>\s*)?$/i;
+
+const isDisplayOnlyToolStatus = (options: AudioTaskOptions): boolean => {
+  if (options.audioBase64 || !options.displayText?.text) {
+    return false;
+  }
+  return TOOL_STATUS_ONLY_RE.test(options.displayText.text);
+};
+
 /**
  * Custom hook for handling audio playback tasks with Live2D lip sync
  */
-export const useAudioTask = () => {
+export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskOptions = {}) => {
   const { t } = useTranslation();
   const { aiState, backendSynthComplete, setBackendSynthComplete } = useAiState();
   const { setSubtitleText } = useSubtitle();
@@ -42,8 +55,9 @@ export const useAudioTask = () => {
     appendResponse,
     appendAIMessage,
   });
-
-  // Note: currentAudioRef and currentModelRef are now managed by the global audioManager
+  const isMountedRef = useRef(true);
+  const backendSynthCompleteRef = useRef(backendSynthComplete);
+  const playbackCompleteAckInFlightRef = useRef(false);
 
   stateRef.current = {
     aiState,
@@ -51,6 +65,7 @@ export const useAudioTask = () => {
     appendResponse,
     appendAIMessage,
   };
+  backendSynthCompleteRef.current = backendSynthComplete;
 
   /**
    * Stop current audio playback and lip sync (delegates to global audioManager)
@@ -70,7 +85,6 @@ export const useAudioTask = () => {
       appendAIMessage: appendAI,
     } = stateRef.current;
 
-    // Skip if already interrupted
     if (currentAiState === 'interrupted') {
       console.warn('Audio playback blocked by interruption state.');
       resolve();
@@ -78,20 +92,22 @@ export const useAudioTask = () => {
     }
 
     const { audioBase64, displayText, expressions, forwarded } = options;
+    const isToolStatus = isDisplayOnlyToolStatus(options);
 
-    // Update display text
     if (displayText) {
       const renderedText = displayText.text;
-      const isToolStatus = !audioBase64 && renderedText.includes('🔧');
-
       appendText(renderedText);
       appendAI(renderedText, displayText.name, displayText.avatar);
+
       if (audioBase64 || isToolStatus) {
         updateSubtitle(renderedText);
       }
-      if (!forwarded) {
+
+      // Only real audio playback should be reported as playback start.
+      if (!forwarded && audioBase64) {
+        console.log(`[PLAYBACK] notifying backend audio task accepted: ${renderedText}`);
         sendMessage({
-          type: "audio-play-start",
+          type: 'audio-play-start',
           display_text: displayText,
           forwarded: true,
         });
@@ -99,7 +115,6 @@ export const useAudioTask = () => {
     }
 
     try {
-      // Process audio if available
       if (audioBase64) {
         if (expressions?.[0] !== undefined) {
           setExpression(
@@ -110,8 +125,6 @@ export const useAudioTask = () => {
         }
 
         const audioDataUrl = `data:audio/wav;base64,${audioBase64}`;
-
-        // Get Live2D manager and model
         const live2dManager = (window as any).getLive2DManager?.();
         if (!live2dManager) {
           console.error('Live2D manager not found');
@@ -133,21 +146,22 @@ export const useAudioTask = () => {
           console.log('Model has _wavFileHandler available');
         }
 
-        // Start talk motion
         if (LAppDefine && LAppDefine.PriorityNormal) {
           console.log("Starting random 'Talk' motion");
           model.startRandomMotion(
-            "Talk",
+            'Talk',
             LAppDefine.PriorityNormal,
           );
         } else {
           console.warn("LAppDefine.PriorityNormal not found - cannot start talk motion");
         }
 
-        // Setup audio element
+        // A real audio segment should immediately replace the temporary tool-status layer.
+        if (displayText) {
+          updateSubtitle(displayText.text);
+        }
+
         const audio = new Audio(audioDataUrl);
-        
-        // Register with global audio manager IMMEDIATELY after creating audio
         audioManager.setCurrentAudio(audio, model);
         let isFinished = false;
 
@@ -159,24 +173,29 @@ export const useAudioTask = () => {
           }
         };
 
-        // Enhance lip sync sensitivity
         const lipSyncScale = 2.0;
 
         audio.addEventListener('canplaythrough', () => {
-          // Check for interruption before playback
           if (stateRef.current.aiState === 'interrupted' || !audioManager.hasCurrentAudio()) {
             console.warn('Audio playback cancelled due to interruption or audio was stopped');
             cleanup();
             return;
           }
 
-          console.log('Starting audio playback with lip sync');
-          audio.play().catch((err) => {
-            console.error("Audio play error:", err);
-            cleanup();
-          });
+          audio.play()
+            .then(() => {
+              console.log(`[PLAYBACK] audio element began audible playback: ${displayText?.text ?? ''}`);
+              sendMessage({
+                type: 'audio-play-began',
+                display_text: displayText ?? undefined,
+                forwarded: true,
+              });
+            })
+            .catch((err) => {
+              console.error('Audio play error:', err);
+              cleanup();
+            });
 
-          // Setup lip sync
           if (model._wavFileHandler) {
             if (!model._wavFileHandler._initialized) {
               console.log('Applying enhanced lip sync');
@@ -200,12 +219,12 @@ export const useAudioTask = () => {
         });
 
         audio.addEventListener('ended', () => {
-          console.log("Audio playback completed");
+          console.log(`[PLAYBACK] audio element completed: ${displayText?.text ?? ''}`);
           cleanup();
         });
 
         audio.addEventListener('error', (error) => {
-          console.error("Audio playback error:", error);
+          console.error('Audio playback error:', error);
           cleanup();
         });
 
@@ -217,32 +236,49 @@ export const useAudioTask = () => {
       console.error('Audio playback setup error:', error);
       toaster.create({
         title: `${t('error.audioPlayback')}: ${error}`,
-        type: "error",
+        type: 'error',
         duration: 2000,
       });
       resolve();
     }
   });
 
-  // Handle backend synthesis completion
+  useEffect(() => () => {
+    isMountedRef.current = false;
+  }, []);
+
   useEffect(() => {
-    let isMounted = true;
+    if (!managePlaybackCompletion) {
+      return;
+    }
+    if (!backendSynthComplete || playbackCompleteAckInFlightRef.current) {
+      return;
+    }
 
-    const handleComplete = async () => {
-      await audioTaskQueue.waitForCompletion();
-      if (isMounted && backendSynthComplete) {
+    playbackCompleteAckInFlightRef.current = true;
+
+    void (async () => {
+      try {
+        await audioTaskQueue.waitForCompletion();
+        if (!isMountedRef.current || !backendSynthCompleteRef.current) {
+          return;
+        }
         stopCurrentAudioAndLipSync();
-        sendMessage({ type: "frontend-playback-complete" });
+        console.log('[PLAYBACK] frontend completed all queued audio for current turn');
+        sendMessage({ type: 'frontend-playback-complete' });
+        backendSynthCompleteRef.current = false;
         setBackendSynthComplete(false);
+      } finally {
+        playbackCompleteAckInFlightRef.current = false;
       }
-    };
-
-    handleComplete();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [backendSynthComplete, sendMessage, setBackendSynthComplete, stopCurrentAudioAndLipSync]);
+    })();
+  }, [
+    backendSynthComplete,
+    managePlaybackCompletion,
+    sendMessage,
+    setBackendSynthComplete,
+    stopCurrentAudioAndLipSync,
+  ]);
 
   /**
    * Add a new audio task to the queue
@@ -255,7 +291,14 @@ export const useAudioTask = () => {
       return;
     }
 
-    console.log(`Adding audio task ${options.displayText?.text} to queue`);
+    // Tool status should show up immediately, but it should not block or impersonate audio playback.
+    if (isDisplayOnlyToolStatus(options)) {
+      console.log(`[PLAYBACK] showing tool status immediately: ${options.displayText?.text}`);
+      await handleAudioPlayback(options);
+      return;
+    }
+
+    console.log(`[PLAYBACK] queueing audio task: ${options.displayText?.text}`);
     audioTaskQueue.addTask(() => handleAudioPlayback(options));
   };
 

--- a/src/renderer/src/hooks/utils/use-audio-task.ts
+++ b/src/renderer/src/hooks/utils/use-audio-task.ts
@@ -30,12 +30,30 @@ interface UseAudioTaskOptions {
 }
 
 const TOOL_STATUS_ONLY_RE = /^\s*(?:<tool>\s*)?\[[^\]]+\]\s*(?:<\/tool>\s*)?$/i;
+const LIP_SYNC_SCALE = 2.0;
+const LIP_SYNC_ATTACK_SECONDS = 0.07;
+const LIP_SYNC_RELEASE_SECONDS = 0.14;
+const LIP_SYNC_MIN_DT_SECONDS = 1 / 240;
+const LIP_SYNC_MAX_DT_SECONDS = 0.12;
 
 const isDisplayOnlyToolStatus = (options: AudioTaskOptions): boolean => {
   if (options.audioBase64 || !options.displayText?.text) {
     return false;
   }
   return TOOL_STATUS_ONLY_RE.test(options.displayText.text);
+};
+
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max);
+
+const smoothLipSyncValue = (previousValue: number, targetValue: number, deltaTimeSeconds: number): number => {
+  const dt = clamp(deltaTimeSeconds, LIP_SYNC_MIN_DT_SECONDS, LIP_SYNC_MAX_DT_SECONDS);
+  const timeConstant = targetValue > previousValue ? LIP_SYNC_ATTACK_SECONDS : LIP_SYNC_RELEASE_SECONDS;
+  if (timeConstant <= 0) {
+    return targetValue;
+  }
+
+  const alpha = 1 - Math.exp(-dt / timeConstant);
+  return previousValue + ((targetValue - previousValue) * alpha);
 };
 
 /**
@@ -180,8 +198,6 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
           }
         };
 
-        const lipSyncScale = 2.0;
-
         audio.addEventListener('canplaythrough', () => {
           if (stateRef.current.aiState === 'interrupted' || !audioManager.hasCurrentAudio()) {
             console.warn('Audio playback cancelled due to interruption or audio was stopped');
@@ -205,20 +221,31 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
             });
 
           if (model._wavFileHandler) {
-            if (!model._wavFileHandler._initialized) {
-              console.log('Applying enhanced lip sync');
-              model._wavFileHandler._initialized = true;
+            if (!model._wavFileHandler.__xnneLipSyncSmoothingInstalled) {
+              console.log('Applying smoothed lip sync');
+              model._wavFileHandler.__xnneLipSyncSmoothingInstalled = true;
+              model._wavFileHandler.__xnneLipSyncSmoothedRms = 0.0;
 
               const originalUpdate = model._wavFileHandler.update.bind(model._wavFileHandler);
               model._wavFileHandler.update = function (deltaTimeSeconds: number) {
                 const result = originalUpdate(deltaTimeSeconds);
                 // @ts-ignore
-                this._lastRms = Math.min(2.0, this._lastRms * lipSyncScale);
+                const previousValue = typeof this.__xnneLipSyncSmoothedRms === 'number'
+                  ? this.__xnneLipSyncSmoothedRms
+                  : 0.0;
+                // @ts-ignore
+                const scaledTarget = clamp(this._lastRms * LIP_SYNC_SCALE, 0.0, 2.0);
+                const smoothedValue = smoothLipSyncValue(previousValue, scaledTarget, deltaTimeSeconds);
+                // @ts-ignore
+                this.__xnneLipSyncSmoothedRms = smoothedValue;
+                // @ts-ignore
+                this._lastRms = smoothedValue;
                 return result;
               };
             }
 
             if (audioManager.hasCurrentAudio()) {
+              model._wavFileHandler.__xnneLipSyncSmoothedRms = 0.0;
               model._wavFileHandler.start(audioDataUrl);
             } else {
               console.warn('WavFileHandler start skipped - audio was stopped');

--- a/src/renderer/src/hooks/utils/use-audio-task.ts
+++ b/src/renderer/src/hooks/utils/use-audio-task.ts
@@ -23,6 +23,7 @@ interface AudioTaskOptions {
   speaker_uid?: string
   forwarded?: boolean
   turnId?: string
+  ttsError?: boolean
 }
 
 interface UseAudioTaskOptions {
@@ -111,7 +112,9 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
       return;
     }
 
-    const { audioBase64, displayText, expressions, forwarded, turnId } = options;
+    const {
+      audioBase64, displayText, expressions, forwarded, turnId, ttsError,
+    } = options;
     const isToolStatus = isDisplayOnlyToolStatus(options);
 
     if (displayText) {
@@ -265,6 +268,13 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
 
         audio.load();
       } else {
+        if (ttsError) {
+          toaster.create({
+            title: t('error.ttsGenerationFailed', { defaultValue: '当前这句语音生成失败，已跳过。' }),
+            type: 'warning',
+            duration: 2000,
+          });
+        }
         resolve();
       }
     } catch (error) {

--- a/src/renderer/src/hooks/utils/use-audio-task.ts
+++ b/src/renderer/src/hooks/utils/use-audio-task.ts
@@ -22,6 +22,7 @@ interface AudioTaskOptions {
   expressions?: string[] | number[] | null
   speaker_uid?: string
   forwarded?: boolean
+  turnId?: string
 }
 
 interface UseAudioTaskOptions {
@@ -58,6 +59,7 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
   const isMountedRef = useRef(true);
   const backendSynthCompleteRef = useRef(backendSynthComplete);
   const playbackCompleteAckInFlightRef = useRef(false);
+  const currentTurnIdRef = useRef<string | null>(null);
 
   stateRef.current = {
     aiState,
@@ -91,7 +93,7 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
       return;
     }
 
-    const { audioBase64, displayText, expressions, forwarded } = options;
+    const { audioBase64, displayText, expressions, forwarded, turnId } = options;
     const isToolStatus = isDisplayOnlyToolStatus(options);
 
     if (displayText) {
@@ -103,6 +105,10 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
         updateSubtitle(renderedText);
       }
 
+      if (turnId) {
+        currentTurnIdRef.current = turnId;
+      }
+
       // Only real audio playback should be reported as playback start.
       if (!forwarded && audioBase64) {
         console.log(`[PLAYBACK] notifying backend audio task accepted: ${renderedText}`);
@@ -110,6 +116,7 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
           type: 'audio-play-start',
           display_text: displayText,
           forwarded: true,
+          turn_id: turnId,
         });
       }
     }
@@ -189,6 +196,7 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
                 type: 'audio-play-began',
                 display_text: displayText ?? undefined,
                 forwarded: true,
+                turn_id: turnId,
               });
             })
             .catch((err) => {
@@ -265,7 +273,7 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
         }
         stopCurrentAudioAndLipSync();
         console.log('[PLAYBACK] frontend completed all queued audio for current turn');
-        sendMessage({ type: 'frontend-playback-complete' });
+        sendMessage({ type: 'frontend-playback-complete', turn_id: currentTurnIdRef.current || undefined });
         backendSynthCompleteRef.current = false;
         setBackendSynthComplete(false);
       } finally {

--- a/src/renderer/src/hooks/utils/use-audio-task.ts
+++ b/src/renderer/src/hooks/utils/use-audio-task.ts
@@ -14,9 +14,6 @@ import { DisplayText } from '@/services/websocket-service';
 import { useLive2DExpression } from '@/hooks/canvas/use-live2d-expression';
 import * as LAppDefine from '../../../WebSDK/src/lappdefine';
 
-// Simple type alias for Live2D model
-type Live2DModel = any;
-
 interface AudioTaskOptions {
   audioBase64: string
   volumes: number[]
@@ -104,6 +101,14 @@ export const useAudioTask = () => {
     try {
       // Process audio if available
       if (audioBase64) {
+        if (expressions?.[0] !== undefined) {
+          setExpression(
+            expressions[0],
+            undefined,
+            `Queued transient expression: ${expressions[0]}`,
+          );
+        }
+
         const audioDataUrl = `data:audio/wav;base64,${audioBase64}`;
 
         // Get Live2D manager and model
@@ -126,16 +131,6 @@ export const useAudioTask = () => {
           console.warn('Model does not have _wavFileHandler for lip sync');
         } else {
           console.log('Model has _wavFileHandler available');
-        }
-
-        // Set expression if available
-        const lappAdapter = (window as any).getLAppAdapter?.();
-        if (lappAdapter && expressions?.[0] !== undefined) {
-          setExpression(
-            expressions[0],
-            lappAdapter,
-            `Set expression to: ${expressions[0]}`,
-          );
         }
 
         // Start talk motion

--- a/src/renderer/src/hooks/utils/use-audio-task.ts
+++ b/src/renderer/src/hooks/utils/use-audio-task.ts
@@ -190,9 +190,7 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
         }
 
         const audio = new Audio(audioDataUrl);
-        audioManager.setCurrentAudio(audio, model);
         let isFinished = false;
-
         const cleanup = () => {
           audioManager.clearCurrentAudio(audio);
           if (!isFinished) {
@@ -200,6 +198,7 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
             resolve();
           }
         };
+        audioManager.setCurrentAudio(audio, model, cleanup);
 
         audio.addEventListener('canplaythrough', () => {
           if (stateRef.current.aiState === 'interrupted' || !audioManager.hasCurrentAudio()) {
@@ -266,6 +265,11 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
           cleanup();
         });
 
+        audio.addEventListener('abort', () => {
+          console.log(`[PLAYBACK] audio element aborted: ${displayText?.text ?? ''}`);
+          cleanup();
+        });
+
         audio.load();
       } else {
         if (ttsError) {
@@ -301,6 +305,7 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
     }
 
     playbackCompleteAckInFlightRef.current = true;
+    const completedTurnId = currentTurnIdRef.current;
 
     void (async () => {
       try {
@@ -309,8 +314,8 @@ export const useAudioTask = ({ managePlaybackCompletion = false }: UseAudioTaskO
           return;
         }
         stopCurrentAudioAndLipSync();
-        console.log('[PLAYBACK] frontend completed all queued audio for current turn');
-        sendMessage({ type: 'frontend-playback-complete', turn_id: currentTurnIdRef.current || undefined });
+        console.log(`[PLAYBACK] frontend completed all queued audio for turn: ${completedTurnId ?? 'unknown'}`);
+        sendMessage({ type: 'frontend-playback-complete', turn_id: completedTurnId || undefined });
         backendSynthCompleteRef.current = false;
         setBackendSynthComplete(false);
       } finally {

--- a/src/renderer/src/hooks/utils/use-interrupt.ts
+++ b/src/renderer/src/hooks/utils/use-interrupt.ts
@@ -6,7 +6,7 @@ import { useSubtitle } from '@/context/subtitle-context';
 import { useAudioTask } from './use-audio-task';
 
 export const useInterrupt = () => {
-  const { aiState, setAiState } = useAiState();
+  const { aiState, setAiState, setBackendSynthComplete } = useAiState();
   const { sendMessage } = useWebSocket();
   const { fullResponse, clearResponse } = useChatHistory();
   // const { currentModel } = useLive2DModel();
@@ -22,6 +22,7 @@ export const useInterrupt = () => {
     audioTaskQueue.clearQueue();
 
     setAiState('interrupted');
+    setBackendSynthComplete(false);
 
     if (sendSignal) {
       sendMessage({

--- a/src/renderer/src/hooks/utils/use-media-capture.tsx
+++ b/src/renderer/src/hooks/utils/use-media-capture.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useCamera } from '@/context/camera-context';
 import { useScreenCaptureContext } from '@/context/screen-capture-context';
 import { toaster } from "@/components/ui/toaster";
+import { ImagePayload } from '@/types/media';
 import {
   IMAGE_COMPRESSION_QUALITY_KEY,
   DEFAULT_IMAGE_COMPRESSION_QUALITY,
@@ -17,12 +18,6 @@ declare class ImageCapture {
   constructor(track: MediaStreamTrack);
 
   grabFrame(): Promise<ImageBitmap>;
-}
-
-export interface ImageData {
-  source: 'camera' | 'screen' | 'upload';
-  data: string;
-  mime_type: string;
 }
 
 export function useMediaCapture() {
@@ -99,7 +94,7 @@ export function useMediaCapture() {
   }, [t, getCompressionQuality, getImageMaxWidth]);
 
   const captureAllMedia = useCallback(async () => {
-    const images: ImageData[] = [];
+    const images: ImagePayload[] = [];
 
     // Capture camera frame
     if (cameraStream) {

--- a/src/renderer/src/hooks/utils/use-media-capture.tsx
+++ b/src/renderer/src/hooks/utils/use-media-capture.tsx
@@ -19,8 +19,8 @@ declare class ImageCapture {
   grabFrame(): Promise<ImageBitmap>;
 }
 
-interface ImageData {
-  source: 'camera' | 'screen';
+export interface ImageData {
+  source: 'camera' | 'screen' | 'upload';
   data: string;
   mime_type: string;
 }

--- a/src/renderer/src/hooks/utils/use-mic-toggle.ts
+++ b/src/renderer/src/hooks/utils/use-mic-toggle.ts
@@ -1,9 +1,12 @@
 import { useVAD } from '@/context/vad-context';
 import { useAiState } from '@/context/ai-state-context';
+import { useConfig } from '@/context/character-config-context';
+import { toaster } from '@/components/ui/toaster';
 
 export function useMicToggle() {
   const { startMic, stopMic, micOn } = useVAD();
   const { aiState, setAiState } = useAiState();
+  const { asrEnabled } = useConfig();
 
   const handleMicToggle = async (): Promise<void> => {
     if (micOn) {
@@ -12,6 +15,14 @@ export function useMicToggle() {
         setAiState('idle');
       }
     } else {
+      if (!asrEnabled) {
+        toaster.create({
+          title: 'ASR 未启用，无法使用语音输入',
+          type: 'warning',
+          duration: 3000,
+        });
+        return;
+      }
       await startMic();
     }
   };

--- a/src/renderer/src/layout.tsx
+++ b/src/renderer/src/layout.tsx
@@ -52,7 +52,8 @@ export const layoutStyles = {
   },
   footer: {
     width: '100%',
-    height: { base: '100px', md: '120px' },
+    height: 'auto',
+    minHeight: { base: '100px', md: '120px' },
     transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
     willChange: 'transform',
     position: 'relative',

--- a/src/renderer/src/live2d/mixer/live2d-parameter-profile.ts
+++ b/src/renderer/src/live2d/mixer/live2d-parameter-profile.ts
@@ -1,0 +1,62 @@
+import { LogicalChannel } from '@/live2d/mixer/logical-channels';
+
+export type Live2DParameterApplyMode = 'set' | 'add';
+
+export interface Live2DParameterTarget {
+  id: string;
+  scale: number;
+
+  /**
+   * Reserved for future layered ownership (mouse attention/event/etc.).
+   * P1/P1.5 default remains `set` to preserve existing behavior.
+   */
+  applyMode?: Live2DParameterApplyMode;
+}
+
+/**
+ * Mapping profile from logical channels -> Live2D parameter IDs.
+ *
+ * First version:
+ * - 1 logical channel can map to 0..N Live2D params (most are 1:1).
+ * - Missing channels are allowed (e.g. `brow_raise` is model-dependent).
+ */
+export type Live2DParameterProfile = Partial<Record<LogicalChannel, Live2DParameterTarget[]>>;
+
+export function getDefaultLive2DParameterProfile(): Live2DParameterProfile {
+  return {
+    head_yaw: [
+      { id: 'ParamAngleX', scale: 30, applyMode: 'set' },
+      { id: 'ParamAngleX2', scale: 30, applyMode: 'set' },
+      { id: 'ParamAngleX3', scale: 30, applyMode: 'set' },
+    ],
+    head_pitch: [
+      { id: 'ParamAngleY', scale: 30, applyMode: 'set' },
+      { id: 'ParamAngleY2', scale: 30, applyMode: 'set' },
+      { id: 'ParamAngleY3', scale: 30, applyMode: 'set' },
+    ],
+    head_roll: [
+      { id: 'ParamAngleZ', scale: 30, applyMode: 'set' },
+      { id: 'ParamAngleZ2', scale: 30, applyMode: 'set' },
+    ],
+    body_yaw: [
+      { id: 'ParamBodyAngleX', scale: 10, applyMode: 'set' },
+      { id: 'bodyX', scale: 30, applyMode: 'set' },
+    ],
+    body_pitch: [
+      { id: 'ParamBodyAngleY', scale: 10, applyMode: 'set' },
+      { id: 'bodyY', scale: 30, applyMode: 'set' },
+    ],
+    body_roll: [
+      { id: 'ParamBodyAngleZ', scale: 10, applyMode: 'set' },
+      { id: 'bodyZ', scale: 30, applyMode: 'set' },
+    ],
+    gaze_x: [{ id: 'ParamEyeBallX', scale: 1, applyMode: 'set' }],
+    gaze_y: [{ id: 'ParamEyeBallY', scale: 1, applyMode: 'set' }],
+    eye_l_open: [{ id: 'ParamEyeLOpen', scale: 1, applyMode: 'set' }],
+    eye_r_open: [{ id: 'ParamEyeROpen', scale: 1, applyMode: 'set' }],
+
+    // brow_raise: model dependent (reserved for future profiles)
+
+    mouth_open: [{ id: 'ParamMouthOpenY', scale: 1, applyMode: 'set' }],
+  };
+}

--- a/src/renderer/src/live2d/mixer/live2d-parameter-profile.ts
+++ b/src/renderer/src/live2d/mixer/live2d-parameter-profile.ts
@@ -58,5 +58,6 @@ export function getDefaultLive2DParameterProfile(): Live2DParameterProfile {
     // brow_raise: model dependent (reserved for future profiles)
 
     mouth_open: [{ id: 'ParamMouthOpenY', scale: 1, applyMode: 'set' }],
+    mouth_form: [{ id: 'ParamMouthForm', scale: 1, applyMode: 'set' }],
   };
 }

--- a/src/renderer/src/live2d/mixer/logical-channels.ts
+++ b/src/renderer/src/live2d/mixer/logical-channels.ts
@@ -1,0 +1,33 @@
+/**
+ * Logical channels decouple business logic from raw Live2D parameter IDs.
+ *
+ * Convention (first version):
+ * - Most channels are normalized to [-1, 1]
+ * - `mouth_open` is normalized to [0, 1]
+ *
+ * NOTE: In the long run, head/eye/body orientation should be driven by the mixer
+ * rather than static expressions. Expressions should stay focused on facial shapes.
+ */
+
+export const LOGICAL_CHANNELS = [
+  'head_yaw',
+  'head_pitch',
+  'head_roll',
+  'body_yaw',
+  'body_pitch',
+  'body_roll',
+  'gaze_x',
+  'gaze_y',
+  'eye_l_open',
+  'eye_r_open',
+  'brow_raise',
+  'mouth_open',
+] as const;
+
+export type LogicalChannel = (typeof LOGICAL_CHANNELS)[number];
+
+export type PoseValues = Partial<Record<LogicalChannel, number>>;
+
+export interface PoseFrame {
+  values: PoseValues;
+}

--- a/src/renderer/src/live2d/mixer/logical-channels.ts
+++ b/src/renderer/src/live2d/mixer/logical-channels.ts
@@ -4,6 +4,7 @@
  * Convention (first version):
  * - Most channels are normalized to [-1, 1]
  * - `mouth_open` is normalized to [0, 1]
+ * - `mouth_form` is normalized to [-1, 1]
  *
  * NOTE: In the long run, head/eye/body orientation should be driven by the mixer
  * rather than static expressions. Expressions should stay focused on facial shapes.
@@ -22,6 +23,7 @@ export const LOGICAL_CHANNELS = [
   'eye_r_open',
   'brow_raise',
   'mouth_open',
+  'mouth_form',
 ] as const;
 
 export type LogicalChannel = (typeof LOGICAL_CHANNELS)[number];

--- a/src/renderer/src/live2d/mixer/pose-mixer.ts
+++ b/src/renderer/src/live2d/mixer/pose-mixer.ts
@@ -18,22 +18,48 @@ export interface PoseLayer {
 }
 
 export interface MixerApplyOptions {
-  mouthOpen?: {
-    preferLayerId?: string;
-  };
+  preferredChannels?: Partial<Record<LogicalChannel, string[]>>;
 }
 
 export class Mixer {
-  private readonly mouthOpenPreferLayerId: string;
+  private readonly preferredChannels: Partial<Record<LogicalChannel, string[]>>;
 
   constructor(options: MixerApplyOptions = {}) {
-    this.mouthOpenPreferLayerId = options.mouthOpen?.preferLayerId ?? 'speech_layer';
+    this.preferredChannels = options.preferredChannels ?? {};
+  }
+
+  private getEffectiveChannelValue(
+    activeLayers: PoseLayer[],
+    layerId: string,
+    channel: LogicalChannel,
+  ): number | null {
+    const layer = activeLayers.find((candidate) => candidate.id === layerId);
+    if (!layer) {
+      return null;
+    }
+
+    const value = layer.frame?.values?.[channel];
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return null;
+    }
+
+    const channelMask = layer.mask?.[channel];
+    const channelWeightMultiplier = typeof channelMask === 'number' && Number.isFinite(channelMask)
+      ? channelMask
+      : 1;
+    const effectiveWeight = layer.weight * channelWeightMultiplier;
+    if (effectiveWeight <= 0) {
+      return null;
+    }
+
+    return value;
   }
 
   /**
    * Blend multiple layers into a final (partial) pose.
    * - Missing channels are allowed
-   * - First version: weighted average blend
+   * - Default path: weighted average blend
+   * - Preferred channels can short-circuit to specific layers after weighting
    */
   public apply(layers: PoseLayer[]): PoseValues {
     const activeLayers = layers.filter((layer) => {
@@ -75,14 +101,21 @@ export class Mixer {
       if (weightSum > 0) {
         finalPose[channel] = weightedSum / weightSum;
       }
-    });
 
-    // Special-case: mouth should prefer speech layer when present.
-    const preferredLayer = activeLayers.find((layer) => layer.id === this.mouthOpenPreferLayerId);
-    const preferredMouthOpen = preferredLayer?.frame?.values?.mouth_open;
-    if (typeof preferredMouthOpen === 'number' && Number.isFinite(preferredMouthOpen)) {
-      finalPose.mouth_open = preferredMouthOpen;
-    }
+      const preferredLayerIds = this.preferredChannels[channel];
+      if (!preferredLayerIds || preferredLayerIds.length === 0) {
+        return;
+      }
+
+      for (let index = 0; index < preferredLayerIds.length; index += 1) {
+        const preferredValue = this.getEffectiveChannelValue(activeLayers, preferredLayerIds[index], channel);
+        if (preferredValue === null) {
+          continue;
+        }
+        finalPose[channel] = preferredValue;
+        break;
+      }
+    });
 
     return finalPose;
   }

--- a/src/renderer/src/live2d/mixer/pose-mixer.ts
+++ b/src/renderer/src/live2d/mixer/pose-mixer.ts
@@ -55,6 +55,33 @@ export class Mixer {
     return value;
   }
 
+  private getEffectiveChannelWeight(
+    activeLayers: PoseLayer[],
+    layerId: string,
+    channel: LogicalChannel,
+  ): number {
+    const layer = activeLayers.find((candidate) => candidate.id === layerId);
+    if (!layer) {
+      return 0;
+    }
+
+    const value = layer.frame?.values?.[channel];
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return 0;
+    }
+
+    const channelMask = layer.mask?.[channel];
+    const channelWeightMultiplier = typeof channelMask === 'number' && Number.isFinite(channelMask)
+      ? channelMask
+      : 1;
+    const effectiveWeight = layer.weight * channelWeightMultiplier;
+    if (!Number.isFinite(effectiveWeight) || effectiveWeight <= 0) {
+      return 0;
+    }
+
+    return effectiveWeight;
+  }
+
   /**
    * Blend multiple layers into a final (partial) pose.
    * - Missing channels are allowed
@@ -107,17 +134,34 @@ export class Mixer {
         return;
       }
 
+      let preferredWeightedSum = 0;
+      let preferredWeightSum = 0;
+
       for (let index = 0; index < preferredLayerIds.length; index += 1) {
-        const preferredValue = this.getEffectiveChannelValue(activeLayers, preferredLayerIds[index], channel);
+        const preferredLayerId = preferredLayerIds[index];
+        const preferredValue = this.getEffectiveChannelValue(activeLayers, preferredLayerId, channel);
         if (preferredValue === null) {
           continue;
         }
-        finalPose[channel] = preferredValue;
-        break;
+
+        const preferredWeight = this.getEffectiveChannelWeight(
+          activeLayers,
+          preferredLayerId,
+          channel,
+        );
+        if (preferredWeight <= 0) {
+          continue;
+        }
+
+        preferredWeightedSum += preferredValue * preferredWeight;
+        preferredWeightSum += preferredWeight;
+      }
+
+      if (preferredWeightSum > 0) {
+        finalPose[channel] = preferredWeightedSum / preferredWeightSum;
       }
     });
 
     return finalPose;
   }
 }
-

--- a/src/renderer/src/live2d/mixer/pose-mixer.ts
+++ b/src/renderer/src/live2d/mixer/pose-mixer.ts
@@ -1,0 +1,90 @@
+import {
+  LOGICAL_CHANNELS,
+  LogicalChannel,
+  PoseFrame,
+  PoseValues,
+} from '@/live2d/mixer/logical-channels';
+
+export interface PoseLayer {
+  id: string;
+  weight: number;
+  frame: PoseFrame | null;
+
+  // Reserved for future extensions (mask / priority / blend mode).
+  enabled?: boolean;
+  priority?: number;
+  blendMode?: 'weighted';
+  mask?: Partial<Record<LogicalChannel, number>>;
+}
+
+export interface MixerApplyOptions {
+  mouthOpen?: {
+    preferLayerId?: string;
+  };
+}
+
+export class Mixer {
+  private readonly mouthOpenPreferLayerId: string;
+
+  constructor(options: MixerApplyOptions = {}) {
+    this.mouthOpenPreferLayerId = options.mouthOpen?.preferLayerId ?? 'speech_layer';
+  }
+
+  /**
+   * Blend multiple layers into a final (partial) pose.
+   * - Missing channels are allowed
+   * - First version: weighted average blend
+   */
+  public apply(layers: PoseLayer[]): PoseValues {
+    const activeLayers = layers.filter((layer) => {
+      if (layer.enabled === false) {
+        return false;
+      }
+      if (!layer.frame) {
+        return false;
+      }
+      return Number.isFinite(layer.weight) && layer.weight > 0;
+    });
+
+    const finalPose: PoseValues = {};
+
+    LOGICAL_CHANNELS.forEach((channel) => {
+      let weightedSum = 0;
+      let weightSum = 0;
+
+      activeLayers.forEach((layer) => {
+        const value = layer.frame?.values?.[channel];
+        if (typeof value !== 'number' || !Number.isFinite(value)) {
+          return;
+        }
+
+        const channelMask = layer.mask?.[channel];
+        const channelWeightMultiplier = typeof channelMask === 'number' && Number.isFinite(channelMask)
+          ? channelMask
+          : 1;
+
+        const effectiveWeight = layer.weight * channelWeightMultiplier;
+        if (effectiveWeight <= 0) {
+          return;
+        }
+
+        weightedSum += value * effectiveWeight;
+        weightSum += effectiveWeight;
+      });
+
+      if (weightSum > 0) {
+        finalPose[channel] = weightedSum / weightSum;
+      }
+    });
+
+    // Special-case: mouth should prefer speech layer when present.
+    const preferredLayer = activeLayers.find((layer) => layer.id === this.mouthOpenPreferLayerId);
+    const preferredMouthOpen = preferredLayer?.frame?.values?.mouth_open;
+    if (typeof preferredMouthOpen === 'number' && Number.isFinite(preferredMouthOpen)) {
+      finalPose.mouth_open = preferredMouthOpen;
+    }
+
+    return finalPose;
+  }
+}
+

--- a/src/renderer/src/live2d/mixer/recorded-idle-driver.ts
+++ b/src/renderer/src/live2d/mixer/recorded-idle-driver.ts
@@ -81,6 +81,7 @@ const MOTION_PARAMETER_CHANNEL_MAP: Record<string, MotionParameterToChannel> = {
   ParamEyeLOpen: { channel: 'eye_l_open', normalizeScale: 1 },
   ParamEyeROpen: { channel: 'eye_r_open', normalizeScale: 1 },
   ParamMouthOpenY: { channel: 'mouth_open', normalizeScale: 1 },
+  ParamMouthForm: { channel: 'mouth_form', normalizeScale: 1 },
 };
 
 function clamp(value: number, min: number, max: number): number {

--- a/src/renderer/src/live2d/mixer/recorded-idle-driver.ts
+++ b/src/renderer/src/live2d/mixer/recorded-idle-driver.ts
@@ -1,0 +1,851 @@
+import { LogicalChannel, PoseValues } from '@/live2d/mixer/logical-channels';
+
+export type IdlePlaybackMode = 'random' | 'random_no_repeat';
+
+export interface IdleBankClip {
+  id?: string;
+  url: string;
+  weight?: number;
+}
+
+export interface IdleBankConfig {
+  clips: IdleBankClip[];
+  mode?: IdlePlaybackMode;
+}
+
+export interface IdlePlayCommand {
+  id?: string;
+  url?: string;
+}
+
+type MotionSegmentType = 0 | 1 | 2 | 3;
+
+interface Motion3Meta {
+  Duration?: number;
+  Loop?: boolean;
+}
+
+interface Motion3Curve {
+  Target?: string;
+  Id?: string;
+  Segments?: number[];
+}
+
+interface Motion3File {
+  Meta?: Motion3Meta;
+  Curves?: Motion3Curve[];
+}
+
+interface MotionKeyframe {
+  timeSeconds: number;
+  value: number;
+}
+
+interface ParsedIdleClip {
+  sourceUrl: string;
+  durationSeconds: number;
+  loop: boolean;
+  channelCurves: Partial<Record<LogicalChannel, MotionKeyframe[]>>;
+}
+
+interface MotionParameterToChannel {
+  channel: LogicalChannel;
+  normalizeScale: number;
+  priority?: number;
+}
+
+const MOTION_PARAMETER_CHANNEL_MAP: Record<string, MotionParameterToChannel> = {
+  ParamAngleX: { channel: 'head_yaw', normalizeScale: 30 },
+  ParamAngleX2: { channel: 'head_yaw', normalizeScale: 30 },
+  ParamAngleX3: { channel: 'head_yaw', normalizeScale: 30 },
+  ParamAngleY: { channel: 'head_pitch', normalizeScale: 30 },
+  ParamAngleY2: { channel: 'head_pitch', normalizeScale: 30 },
+  ParamAngleY3: { channel: 'head_pitch', normalizeScale: 30 },
+  ParamAngleZ: { channel: 'head_roll', normalizeScale: 30 },
+  ParamAngleZ2: { channel: 'head_roll', normalizeScale: 30 },
+  ParamBodyAngleX: { channel: 'body_yaw', normalizeScale: 10, priority: 0 },
+  ParamBodyAngleY: { channel: 'body_pitch', normalizeScale: 10, priority: 0 },
+  ParamBodyAngleZ: { channel: 'body_roll', normalizeScale: 10, priority: 0 },
+  bodyX: { channel: 'body_yaw', normalizeScale: 30, priority: 1 },
+  bodyX2: { channel: 'body_yaw', normalizeScale: 30, priority: 2 },
+  bodyX3: { channel: 'body_yaw', normalizeScale: 30, priority: 2 },
+  bodyY: { channel: 'body_pitch', normalizeScale: 30, priority: 1 },
+  bodyZ: { channel: 'body_roll', normalizeScale: 30, priority: 1 },
+  bodyZ2: { channel: 'body_roll', normalizeScale: 30, priority: 2 },
+  bodyZZ: { channel: 'body_roll', normalizeScale: 30, priority: 2 },
+  bodyZZ2: { channel: 'body_roll', normalizeScale: 30, priority: 2 },
+  ParamEyeBallX: { channel: 'gaze_x', normalizeScale: 1 },
+  ParamEyeBallY: { channel: 'gaze_y', normalizeScale: 1 },
+  // 若录制 idle 提供眼皮曲线，则优先由录制数据驱动，
+  // 避免 SDK 自动眨眼在 idle 播放期间“抢控制权”。
+  ParamEyeLOpen: { channel: 'eye_l_open', normalizeScale: 1 },
+  ParamEyeROpen: { channel: 'eye_r_open', normalizeScale: 1 },
+  ParamMouthOpenY: { channel: 'mouth_open', normalizeScale: 1 },
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+// 当前故意关闭 loop seam 混合：
+// 边界统一走一条输出过渡链路，避免“双重混合”带来的跳变。
+const LOOP_SEAM_BLEND_SECONDS = 0.0;
+
+// 核心衔接时长，覆盖两种场景：
+// - 同 clip 循环边界（尾帧 -> 新一轮开头）
+// - random 切 clip（上一段 -> 下一段）
+// 该过渡发生在输出层，不计入 clip 播放时长。
+const CLIP_TRANSITION_BLEND_SECONDS = 1.0;
+
+// 输出姿态的最终低通平滑，用于吸收采样抖动。
+const OUTPUT_POSE_SMOOTH_SECONDS = 0.22;
+
+function blendChannelValue(fromValue: number | undefined, toValue: number | undefined, alpha: number): number | null {
+  const hasFrom = typeof fromValue === 'number' && Number.isFinite(fromValue);
+  const hasTo = typeof toValue === 'number' && Number.isFinite(toValue);
+  if (!hasFrom && !hasTo) {
+    return null;
+  }
+
+  if (!hasFrom) {
+    return toValue as number;
+  }
+  if (!hasTo) {
+    return fromValue;
+  }
+
+  return fromValue + ((toValue as number) - fromValue) * alpha;
+}
+
+function blendPose(fromPose: PoseValues, toPose: PoseValues, alpha: number): PoseValues {
+  const boundedAlpha = clamp(alpha, 0, 1);
+  const pose: PoseValues = {};
+  const channels = new Set<LogicalChannel>([
+    ...(Object.keys(fromPose) as LogicalChannel[]),
+    ...(Object.keys(toPose) as LogicalChannel[]),
+  ]);
+
+  channels.forEach((channel) => {
+    const blended = blendChannelValue(fromPose[channel], toPose[channel], boundedAlpha);
+    if (blended === null) {
+      return;
+    }
+    pose[channel] = blended;
+  });
+
+  return pose;
+}
+
+function normalizeMotionSegmentType(value: number): MotionSegmentType | null {
+  if (value === 0 || value === 1 || value === 2 || value === 3) {
+    return value;
+  }
+  return null;
+}
+
+function parseCurveKeyframes(segments: number[] | undefined): MotionKeyframe[] {
+  if (!segments || segments.length < 2) {
+    return [];
+  }
+
+  const keyframes: MotionKeyframe[] = [];
+  const startTime = segments[0];
+  const startValue = segments[1];
+  if (Number.isFinite(startTime) && Number.isFinite(startValue)) {
+    keyframes.push({
+      timeSeconds: startTime,
+      value: startValue,
+    });
+  }
+
+  let cursor = 2;
+  while (cursor < segments.length) {
+    const segmentType = normalizeMotionSegmentType(segments[cursor]);
+    if (segmentType === null) {
+      break;
+    }
+    cursor += 1;
+
+    let endTime = Number.NaN;
+    let endValue = Number.NaN;
+
+    switch (segmentType) {
+      case 0: {
+        // Linear: [type, time, value]
+        if (cursor + 1 >= segments.length) {
+          return keyframes;
+        }
+        endTime = segments[cursor];
+        endValue = segments[cursor + 1];
+        cursor += 2;
+        break;
+      }
+      case 1: {
+        // Bezier (restricted or unrestricted): [type, c1t, c1v, c2t, c2v, endT, endV]
+        if (cursor + 5 >= segments.length) {
+          return keyframes;
+        }
+        endTime = segments[cursor + 4];
+        endValue = segments[cursor + 5];
+        cursor += 6;
+        break;
+      }
+      case 2:
+      case 3: {
+        // Stepped / inverse stepped: [type, time, value]
+        if (cursor + 1 >= segments.length) {
+          return keyframes;
+        }
+        endTime = segments[cursor];
+        endValue = segments[cursor + 1];
+        cursor += 2;
+        break;
+      }
+      default:
+        return keyframes;
+    }
+
+    if (!Number.isFinite(endTime) || !Number.isFinite(endValue)) {
+      continue;
+    }
+
+    if (keyframes.length > 0 && endTime < keyframes[keyframes.length - 1].timeSeconds) {
+      continue;
+    }
+
+    keyframes.push({
+      timeSeconds: endTime,
+      value: endValue,
+    });
+  }
+
+  return keyframes;
+}
+
+function sampleCurveValueAtTime(curve: MotionKeyframe[], timeSeconds: number): number {
+  if (curve.length === 0) {
+    return 0;
+  }
+
+  if (timeSeconds <= curve[0].timeSeconds) {
+    return curve[0].value;
+  }
+
+  const last = curve[curve.length - 1];
+  if (timeSeconds >= last.timeSeconds) {
+    return last.value;
+  }
+
+  let left = 0;
+  let right = curve.length - 1;
+  while (left <= right) {
+    const mid = Math.floor((left + right) / 2);
+    const midTime = curve[mid].timeSeconds;
+    if (midTime === timeSeconds) {
+      return curve[mid].value;
+    }
+    if (midTime < timeSeconds) {
+      left = mid + 1;
+    } else {
+      right = mid - 1;
+    }
+  }
+
+  const nextIndex = clamp(left, 1, curve.length - 1);
+  const prevIndex = nextIndex - 1;
+  const prev = curve[prevIndex];
+  const next = curve[nextIndex];
+  const duration = next.timeSeconds - prev.timeSeconds;
+  if (duration <= 0) {
+    return next.value;
+  }
+
+  const t = (timeSeconds - prev.timeSeconds) / duration;
+  return prev.value + (next.value - prev.value) * t;
+}
+
+function getCurveRange(curve: MotionKeyframe[]): number {
+  if (curve.length === 0) {
+    return 0;
+  }
+
+  let minValue = curve[0].value;
+  let maxValue = curve[0].value;
+  for (let index = 1; index < curve.length; index += 1) {
+    const value = curve[index].value;
+    if (value < minValue) {
+      minValue = value;
+    }
+    if (value > maxValue) {
+      maxValue = value;
+    }
+  }
+  return maxValue - minValue;
+}
+
+function parseMotion3Clip(sourceUrl: string, data: Motion3File): ParsedIdleClip | null {
+  const durationSeconds = Number.isFinite(data.Meta?.Duration) ? Number(data.Meta?.Duration) : 0;
+  if (durationSeconds <= 0) {
+    return null;
+  }
+
+  const channelCurves: Partial<Record<LogicalChannel, MotionKeyframe[]>> = {};
+  const channelCurveMeta: Partial<Record<LogicalChannel, { priority: number; range: number; keyCount: number }>> = {};
+
+  (data.Curves ?? []).forEach((curve) => {
+    if (curve.Target !== 'Parameter' || typeof curve.Id !== 'string') {
+      return;
+    }
+
+    const mapping = MOTION_PARAMETER_CHANNEL_MAP[curve.Id];
+    if (!mapping) {
+      return;
+    }
+
+    const keyframes = parseCurveKeyframes(curve.Segments);
+    if (keyframes.length === 0) {
+      return;
+    }
+
+    const normalized = keyframes.map((point) => ({
+      timeSeconds: point.timeSeconds,
+      value: point.value / mapping.normalizeScale,
+    }));
+
+    const nextPriority = mapping.priority ?? 0;
+    const nextRange = getCurveRange(normalized);
+    const nextKeyCount = normalized.length;
+    const existing = channelCurves[mapping.channel];
+    const existingMeta = channelCurveMeta[mapping.channel];
+    if (!existing) {
+      channelCurves[mapping.channel] = normalized;
+      channelCurveMeta[mapping.channel] = {
+        priority: nextPriority,
+        range: nextRange,
+        keyCount: nextKeyCount,
+      };
+      return;
+    }
+
+    const shouldReplace = !existingMeta
+      || nextPriority < existingMeta.priority
+      || (nextPriority === existingMeta.priority
+        && (nextRange > existingMeta.range
+          || (Math.abs(nextRange - existingMeta.range) <= 1e-6 && nextKeyCount > existingMeta.keyCount)));
+    if (shouldReplace) {
+      channelCurves[mapping.channel] = normalized;
+      channelCurveMeta[mapping.channel] = {
+        priority: nextPriority,
+        range: nextRange,
+        keyCount: nextKeyCount,
+      };
+    }
+  });
+
+  if (Object.keys(channelCurves).length === 0) {
+    return null;
+  }
+
+  return {
+    sourceUrl,
+    durationSeconds,
+    loop: data.Meta?.Loop === true,
+    channelCurves,
+  };
+}
+
+function toAbsoluteUrl(pathOrUrl: string, modelUrl?: string): string {
+  const trimmed = pathOrUrl.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (/^(https?:)?\/\//i.test(trimmed) || /^data:/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  try {
+    if (modelUrl) {
+      return new URL(trimmed, modelUrl).toString();
+    }
+    return new URL(trimmed, window.location.href).toString();
+  } catch {
+    return trimmed;
+  }
+}
+
+function sanitizeClip(clip: IdleBankClip): IdleBankClip | null {
+  const normalizedUrl = typeof clip.url === 'string' ? clip.url.trim() : '';
+  if (!normalizedUrl) {
+    return null;
+  }
+
+  const normalizedWeight = typeof clip.weight === 'number' && Number.isFinite(clip.weight)
+    ? Math.max(0, clip.weight)
+    : undefined;
+
+  return {
+    id: typeof clip.id === 'string' && clip.id.trim() ? clip.id.trim() : undefined,
+    url: normalizedUrl,
+    weight: normalizedWeight,
+  };
+}
+
+export function normalizeIdleBankConfig(input: IdleBankConfig | null | undefined): IdleBankConfig | null {
+  if (!input || !Array.isArray(input.clips)) {
+    return null;
+  }
+
+  const clips = input.clips
+    .map((clip) => sanitizeClip(clip))
+    .filter((clip): clip is IdleBankClip => clip !== null);
+
+  if (clips.length === 0) {
+    return null;
+  }
+
+  const mode = input.mode === 'random' || input.mode === 'random_no_repeat'
+    ? input.mode
+    : 'random_no_repeat';
+
+  return {
+    clips,
+    mode,
+  };
+}
+
+function normalizeIdlePlayCommand(input: IdlePlayCommand | string | null | undefined): IdlePlayCommand | null {
+  if (typeof input === 'string') {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return null;
+    }
+    if (trimmed.includes('/') || trimmed.includes('\\') || trimmed.includes('.')) {
+      return { url: trimmed };
+    }
+    return { id: trimmed };
+  }
+
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+
+  const id = typeof input.id === 'string' && input.id.trim() ? input.id.trim() : undefined;
+  const url = typeof input.url === 'string' && input.url.trim() ? input.url.trim() : undefined;
+  if (!id && !url) {
+    return null;
+  }
+  return { id, url };
+}
+
+type IdleClipSource = 'bank' | 'manual';
+
+export class RecordedIdleDriver {
+  private readonly clipCache = new Map<string, Promise<ParsedIdleClip | null>>();
+
+  private modelUrl?: string;
+
+  private bank: IdleBankConfig | null = null;
+
+  private isLoading = false;
+
+  private activeClip: ParsedIdleClip | null = null;
+
+  private activeClipIndex = -1;
+
+  private activeClipSource: IdleClipSource = 'bank';
+
+  private previousClipIndex = -1;
+
+  private activeClipStartTimeSeconds = 0;
+
+  private transitionFromPose: PoseValues | null = null;
+
+  private transitionStartTimeSeconds: number | null = null;
+
+  private requestToken = 0;
+
+  private latestPose: PoseValues = {};
+
+  private smoothedPose: PoseValues = {};
+
+  private lastOutputTimeSeconds: number | null = null;
+
+  constructor(private readonly onPose: (pose: PoseValues) => void) {}
+
+  public setModelUrl(modelUrl?: string): void {
+    if (this.modelUrl === modelUrl) {
+      return;
+    }
+
+    this.modelUrl = modelUrl;
+    this.resetPlaybackState();
+  }
+
+  public setIdleBank(bank: IdleBankConfig | null): void {
+    const normalized = normalizeIdleBankConfig(bank);
+    this.bank = normalized;
+    this.resetPlaybackState();
+
+    if (!this.bank) {
+      this.pushPose({});
+    }
+  }
+
+  public clearIdleBank(): void {
+    this.bank = null;
+    this.resetPlaybackState();
+    this.pushPose({});
+  }
+
+  public playManualClip(command: IdlePlayCommand | string | null | undefined, nowSeconds: number): void {
+    const normalized = normalizeIdlePlayCommand(command);
+    if (!normalized || !Number.isFinite(nowSeconds)) {
+      return;
+    }
+
+    const fromBank = normalized.id
+      ? this.bank?.clips.findIndex((clip) => clip.id === normalized.id) ?? -1
+      : -1;
+
+    if (fromBank >= 0 && this.bank) {
+      void this.selectClip(nowSeconds, this.bank.clips[fromBank], fromBank, 'manual');
+      return;
+    }
+
+    if (!normalized.url) {
+      return;
+    }
+
+    const sanitized = sanitizeClip({
+      id: normalized.id,
+      url: normalized.url,
+    });
+    if (!sanitized) {
+      return;
+    }
+
+    void this.selectClip(nowSeconds, sanitized, -1, 'manual');
+  }
+
+  public update(nowSeconds: number): void {
+    if (!this.activeClip && (!this.bank || this.bank.clips.length === 0)) {
+      return;
+    }
+
+    if (!Number.isFinite(nowSeconds)) {
+      return;
+    }
+
+    if (!this.activeClip) {
+      if (!this.isLoading && this.bank && this.bank.clips.length > 0) {
+        void this.selectNextClip(nowSeconds);
+      }
+      return;
+    }
+
+    const duration = Math.max(0.001, this.activeClip.durationSeconds);
+    let elapsed = nowSeconds - this.activeClipStartTimeSeconds;
+    if (elapsed >= duration) {
+      if (this.activeClipSource === 'manual') {
+        this.activeClip = null;
+        this.activeClipIndex = -1;
+        this.activeClipSource = 'bank';
+        if (this.bank && this.bank.clips.length > 0) {
+          void this.selectNextClip(nowSeconds);
+        } else {
+          this.pushPose({});
+        }
+        return;
+      }
+
+      if (this.bank && this.bank.clips.length === 1 && this.activeClip.loop) {
+        // 保持播放时间连续（elapsed 回卷），并在输出层做短过渡，
+        // 这样边界平滑不会“吃掉”动画时间。
+        // 关键点：以最近一次已输出的姿态作为过渡起点，
+        // 保证从用户当前看到的画面自然接续。
+        const tailPose = Object.keys(this.latestPose).length > 0
+          ? { ...this.latestPose }
+          : this.samplePose(this.activeClip, duration);
+        elapsed %= duration;
+        this.activeClipStartTimeSeconds = nowSeconds - elapsed;
+        this.transitionFromPose = tailPose;
+        this.transitionStartTimeSeconds = nowSeconds;
+      } else {
+        void this.selectNextClip(nowSeconds);
+        return;
+      }
+    }
+
+    const boundedElapsed = Math.min(Math.max(0, elapsed), duration);
+    let pose = this.samplePoseWithLoopSeamBlend(this.activeClip, boundedElapsed);
+
+    if (this.transitionFromPose && this.transitionStartTimeSeconds !== null) {
+      const transitionElapsed = nowSeconds - this.transitionStartTimeSeconds;
+      const transitionAlpha = clamp(transitionElapsed / CLIP_TRANSITION_BLEND_SECONDS, 0, 1);
+      pose = blendPose(this.transitionFromPose, pose, transitionAlpha);
+
+      if (transitionAlpha >= 1) {
+        this.transitionFromPose = null;
+        this.transitionStartTimeSeconds = null;
+      }
+    }
+
+    const smoothedPose = this.smoothOutputPose(pose, nowSeconds);
+    this.pushPose(smoothedPose);
+  }
+
+  public getDebugState() {
+    const clip = this.activeClipIndex >= 0 ? this.bank?.clips[this.activeClipIndex] : undefined;
+    return {
+      hasBank: Boolean(this.bank),
+      mode: this.bank?.mode ?? null,
+      clipCount: this.bank?.clips.length ?? 0,
+      isLoading: this.isLoading,
+      modelUrl: this.modelUrl ?? null,
+      activeClipSource: this.activeClipSource,
+      activeClipIndex: this.activeClipIndex,
+      activeClipId: clip?.id ?? null,
+      activeClipUrl: clip?.url ?? null,
+      activeClipResolvedUrl: this.activeClip?.sourceUrl ?? null,
+      activeClipDurationSeconds: this.activeClip?.durationSeconds ?? null,
+      latestPose: { ...this.latestPose },
+    };
+  }
+
+  private resetPlaybackState(): void {
+    this.requestToken += 1;
+    this.isLoading = false;
+    this.activeClip = null;
+    this.activeClipIndex = -1;
+    this.activeClipSource = 'bank';
+    this.previousClipIndex = -1;
+    this.activeClipStartTimeSeconds = 0;
+    this.transitionFromPose = null;
+    this.transitionStartTimeSeconds = null;
+    this.smoothedPose = {};
+    this.lastOutputTimeSeconds = null;
+  }
+
+  private pushPose(pose: PoseValues): void {
+    this.latestPose = { ...pose };
+    this.onPose(this.latestPose);
+  }
+
+  private smoothOutputPose(targetPose: PoseValues, nowSeconds: number): PoseValues {
+    if (!Number.isFinite(nowSeconds)) {
+      return targetPose;
+    }
+
+    if (OUTPUT_POSE_SMOOTH_SECONDS <= 0) {
+      this.smoothedPose = { ...targetPose };
+      this.lastOutputTimeSeconds = nowSeconds;
+      return targetPose;
+    }
+
+    const targetChannels = Object.keys(targetPose) as LogicalChannel[];
+    if (targetChannels.length === 0) {
+      this.smoothedPose = {};
+      this.lastOutputTimeSeconds = nowSeconds;
+      return {};
+    }
+
+    const previousTimeSeconds = this.lastOutputTimeSeconds;
+    if (previousTimeSeconds === null) {
+      this.smoothedPose = { ...targetPose };
+      this.lastOutputTimeSeconds = nowSeconds;
+      return { ...targetPose };
+    }
+
+    // 指数平滑 + dt 补偿，降低不同帧率下的可见卡顿感。
+    const dtSeconds = clamp(nowSeconds - previousTimeSeconds, 1 / 240, 0.2);
+    const alpha = 1 - Math.exp(-dtSeconds / OUTPUT_POSE_SMOOTH_SECONDS);
+    const nextPose: PoseValues = {};
+
+    targetChannels.forEach((channel) => {
+      const targetValue = targetPose[channel];
+      if (typeof targetValue !== 'number' || !Number.isFinite(targetValue)) {
+        return;
+      }
+
+      const previousValue = this.smoothedPose[channel];
+      const fromValue = typeof previousValue === 'number' && Number.isFinite(previousValue)
+        ? previousValue
+        : targetValue;
+
+      nextPose[channel] = fromValue + (targetValue - fromValue) * alpha;
+    });
+
+    this.smoothedPose = nextPose;
+    this.lastOutputTimeSeconds = nowSeconds;
+    return nextPose;
+  }
+
+  private samplePose(clip: ParsedIdleClip, elapsedSeconds: number): PoseValues {
+    const pose: PoseValues = {};
+
+    (Object.keys(clip.channelCurves) as LogicalChannel[]).forEach((channel) => {
+      const curve = clip.channelCurves[channel];
+      if (!curve || curve.length === 0) {
+        return;
+      }
+
+      pose[channel] = sampleCurveValueAtTime(curve, elapsedSeconds);
+    });
+
+    return pose;
+  }
+
+  private samplePoseWithLoopSeamBlend(clip: ParsedIdleClip, elapsedSeconds: number): PoseValues {
+    const duration = Math.max(0.001, clip.durationSeconds);
+    if (!clip.loop) {
+      return this.samplePose(clip, elapsedSeconds);
+    }
+
+    const wrappedElapsed = elapsedSeconds % duration;
+    const poseAtTime = this.samplePose(clip, wrappedElapsed);
+    const seamWindow = Math.min(LOOP_SEAM_BLEND_SECONDS, duration * 0.25);
+    if (seamWindow <= 0 || wrappedElapsed < duration - seamWindow) {
+      return poseAtTime;
+    }
+
+    const nearLoopAlpha = (wrappedElapsed - (duration - seamWindow)) / seamWindow;
+    const loopStartPose = this.samplePose(clip, 0);
+    return blendPose(poseAtTime, loopStartPose, nearLoopAlpha);
+  }
+
+  private pickWeightedRandomIndex(candidateIndexes: number[]): number {
+    if (!this.bank || candidateIndexes.length === 0) {
+      return -1;
+    }
+
+    const weighted = candidateIndexes.map((index) => {
+      const weight = this.bank?.clips[index]?.weight;
+      const normalized = typeof weight === 'number' && Number.isFinite(weight) ? Math.max(0, weight) : 1;
+      return { index, weight: normalized };
+    });
+
+    const totalWeight = weighted.reduce((sum, item) => sum + item.weight, 0);
+    if (totalWeight <= 0) {
+      const randomIndex = Math.floor(Math.random() * candidateIndexes.length);
+      return candidateIndexes[randomIndex];
+    }
+
+    let cursor = Math.random() * totalWeight;
+    for (let i = 0; i < weighted.length; i += 1) {
+      cursor -= weighted[i].weight;
+      if (cursor <= 0) {
+        return weighted[i].index;
+      }
+    }
+
+    return weighted[weighted.length - 1].index;
+  }
+
+  private pickNextClipIndex(): number {
+    if (!this.bank || this.bank.clips.length === 0) {
+      return -1;
+    }
+
+    const clipCount = this.bank.clips.length;
+    const allIndexes = Array.from({ length: clipCount }, (_, index) => index);
+    const mode = this.bank.mode ?? 'random_no_repeat';
+
+    if (mode === 'random_no_repeat' && clipCount > 1 && this.previousClipIndex >= 0) {
+      const withoutPrevious = allIndexes.filter((index) => index !== this.previousClipIndex);
+      return this.pickWeightedRandomIndex(withoutPrevious);
+    }
+
+    return this.pickWeightedRandomIndex(allIndexes);
+  }
+
+  private async selectNextClip(nowSeconds: number): Promise<void> {
+    if (!this.bank || this.bank.clips.length === 0) {
+      return;
+    }
+
+    const nextIndex = this.pickNextClipIndex();
+    if (nextIndex < 0) {
+      return;
+    }
+
+    await this.selectClip(nowSeconds, this.bank.clips[nextIndex], nextIndex, 'bank');
+  }
+
+  private activateClip(
+    parsedClip: ParsedIdleClip,
+    nowSeconds: number,
+    source: IdleClipSource,
+    clipIndex: number,
+  ): void {
+    const previousPose = this.latestPose;
+
+    if (source === 'bank' && clipIndex >= 0) {
+      this.previousClipIndex = clipIndex;
+    }
+
+    this.activeClipSource = source;
+    this.activeClipIndex = clipIndex;
+    this.activeClip = parsedClip;
+    this.activeClipStartTimeSeconds = nowSeconds;
+    this.transitionFromPose = Object.keys(previousPose).length > 0 ? { ...previousPose } : null;
+    this.transitionStartTimeSeconds = this.transitionFromPose ? nowSeconds : null;
+
+    const initialPose = this.samplePoseWithLoopSeamBlend(parsedClip, 0);
+    this.pushPose(this.transitionFromPose ? blendPose(this.transitionFromPose, initialPose, 0) : initialPose);
+  }
+
+  private async selectClip(
+    nowSeconds: number,
+    selectedClip: IdleBankClip,
+    clipIndex: number,
+    source: IdleClipSource,
+  ): Promise<void> {
+    const resolvedUrl = toAbsoluteUrl(selectedClip.url, this.modelUrl);
+    if (!resolvedUrl) {
+      return;
+    }
+
+    this.isLoading = true;
+    const token = ++this.requestToken;
+
+    const parsedClip = await this.loadClip(resolvedUrl);
+    if (token !== this.requestToken) {
+      return;
+    }
+
+    this.isLoading = false;
+
+    if (!parsedClip) {
+      return;
+    }
+
+    this.activateClip(parsedClip, nowSeconds, source, clipIndex);
+  }
+
+  private async loadClip(resolvedUrl: string): Promise<ParsedIdleClip | null> {
+    const cached = this.clipCache.get(resolvedUrl);
+    if (cached) {
+      return cached;
+    }
+
+    const loader = (async () => {
+      try {
+        const response = await fetch(resolvedUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch idle clip: ${response.status}`);
+        }
+
+        const motion3 = await response.json() as Motion3File;
+        const parsed = parseMotion3Clip(resolvedUrl, motion3);
+        return parsed;
+      } catch (error) {
+        console.warn('[RecordedIdleDriver] failed to load idle clip:', resolvedUrl, error);
+        return null;
+      }
+    })();
+
+    this.clipCache.set(resolvedUrl, loader);
+    return loader;
+  }
+}

--- a/src/renderer/src/live2d/mixer/recorded-idle-driver.ts
+++ b/src/renderer/src/live2d/mixer/recorded-idle-driver.ts
@@ -421,6 +421,33 @@ export function normalizeIdleBankConfig(input: IdleBankConfig | null | undefined
   };
 }
 
+function getIdleBankPlaybackKey(bank: IdleBankConfig | null, modelUrl?: string): string {
+  if (!bank || bank.clips.length === 0) {
+    return '';
+  }
+
+  return bank.clips
+    .map((clip) => toAbsoluteUrl(clip.url, modelUrl))
+    .sort()
+    .join('|');
+}
+
+function areIdleBanksPlaybackCompatible(
+  left: IdleBankConfig | null,
+  right: IdleBankConfig | null,
+  modelUrl?: string,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (!left || !right) {
+    return false;
+  }
+
+  return getIdleBankPlaybackKey(left, modelUrl) === getIdleBankPlaybackKey(right, modelUrl);
+}
+
 function normalizeIdlePlayCommand(input: IdlePlayCommand | string | null | undefined): IdlePlayCommand | null {
   if (typeof input === 'string') {
     const trimmed = input.trim();
@@ -493,8 +520,15 @@ export class RecordedIdleDriver {
 
   public setIdleBank(bank: IdleBankConfig | null): void {
     const normalized = normalizeIdleBankConfig(bank);
-    const transitionSource = this.captureCurrentTransitionSource();
+    const shouldPreservePlayback = this.activeClip !== null
+      && areIdleBanksPlaybackCompatible(this.bank, normalized, this.modelUrl);
     this.bank = normalized;
+
+    if (shouldPreservePlayback) {
+      return;
+    }
+
+    const transitionSource = this.captureCurrentTransitionSource();
     this.resetPlaybackState(transitionSource);
 
     if (!this.bank) {

--- a/src/renderer/src/live2d/mixer/recorded-idle-driver.ts
+++ b/src/renderer/src/live2d/mixer/recorded-idle-driver.ts
@@ -48,6 +48,12 @@ interface ParsedIdleClip {
   channelCurves: Partial<Record<LogicalChannel, MotionKeyframe[]>>;
 }
 
+interface TransitionPlaybackSource {
+  clip: ParsedIdleClip | null;
+  clipStartTimeSeconds: number | null;
+  fallbackPose: PoseValues;
+}
+
 interface MotionParameterToChannel {
   channel: LogicalChannel;
   normalizeScale: number;
@@ -96,10 +102,10 @@ const LOOP_SEAM_BLEND_SECONDS = 0.0;
 // - 同 clip 循环边界（尾帧 -> 新一轮开头）
 // - random 切 clip（上一段 -> 下一段）
 // 该过渡发生在输出层，不计入 clip 播放时长。
-const CLIP_TRANSITION_BLEND_SECONDS = 1.0;
+const CLIP_TRANSITION_BLEND_SECONDS = 2.0;
 
 // 输出姿态的最终低通平滑，用于吸收采样抖动。
-const OUTPUT_POSE_SMOOTH_SECONDS = 0.22;
+const OUTPUT_POSE_SMOOTH_SECONDS = 0.44;
 
 function blendChannelValue(fromValue: number | undefined, toValue: number | undefined, alpha: number): number | null {
   const hasFrom = typeof fromValue === 'number' && Number.isFinite(fromValue);
@@ -460,7 +466,9 @@ export class RecordedIdleDriver {
 
   private activeClipStartTimeSeconds = 0;
 
-  private transitionFromPose: PoseValues | null = null;
+  private queuedTransitionSource: TransitionPlaybackSource | null = null;
+
+  private transitionSource: TransitionPlaybackSource | null = null;
 
   private transitionStartTimeSeconds: number | null = null;
 
@@ -485,8 +493,9 @@ export class RecordedIdleDriver {
 
   public setIdleBank(bank: IdleBankConfig | null): void {
     const normalized = normalizeIdleBankConfig(bank);
+    const transitionSource = this.captureCurrentTransitionSource();
     this.bank = normalized;
-    this.resetPlaybackState();
+    this.resetPlaybackState(transitionSource);
 
     if (!this.bank) {
       this.pushPose({});
@@ -494,8 +503,9 @@ export class RecordedIdleDriver {
   }
 
   public clearIdleBank(): void {
+    const transitionSource = this.captureCurrentTransitionSource();
     this.bank = null;
-    this.resetPlaybackState();
+    this.resetPlaybackState(transitionSource);
     this.pushPose({});
   }
 
@@ -570,7 +580,11 @@ export class RecordedIdleDriver {
           : this.samplePose(this.activeClip, duration);
         elapsed %= duration;
         this.activeClipStartTimeSeconds = nowSeconds - elapsed;
-        this.transitionFromPose = tailPose;
+        this.transitionSource = {
+          clip: null,
+          clipStartTimeSeconds: null,
+          fallbackPose: tailPose,
+        };
         this.transitionStartTimeSeconds = nowSeconds;
       } else {
         void this.selectNextClip(nowSeconds);
@@ -581,13 +595,13 @@ export class RecordedIdleDriver {
     const boundedElapsed = Math.min(Math.max(0, elapsed), duration);
     let pose = this.samplePoseWithLoopSeamBlend(this.activeClip, boundedElapsed);
 
-    if (this.transitionFromPose && this.transitionStartTimeSeconds !== null) {
+    if (this.transitionSource && this.transitionStartTimeSeconds !== null) {
       const transitionElapsed = nowSeconds - this.transitionStartTimeSeconds;
       const transitionAlpha = clamp(transitionElapsed / CLIP_TRANSITION_BLEND_SECONDS, 0, 1);
-      pose = blendPose(this.transitionFromPose, pose, transitionAlpha);
+      pose = blendPose(this.sampleTransitionSource(this.transitionSource, nowSeconds), pose, transitionAlpha);
 
       if (transitionAlpha >= 1) {
-        this.transitionFromPose = null;
+        this.transitionSource = null;
         this.transitionStartTimeSeconds = null;
       }
     }
@@ -614,7 +628,7 @@ export class RecordedIdleDriver {
     };
   }
 
-  private resetPlaybackState(): void {
+  private resetPlaybackState(queuedTransitionSource: TransitionPlaybackSource | null = null): void {
     this.requestToken += 1;
     this.isLoading = false;
     this.activeClip = null;
@@ -622,10 +636,51 @@ export class RecordedIdleDriver {
     this.activeClipSource = 'bank';
     this.previousClipIndex = -1;
     this.activeClipStartTimeSeconds = 0;
-    this.transitionFromPose = null;
+    this.queuedTransitionSource = queuedTransitionSource;
+    this.transitionSource = null;
     this.transitionStartTimeSeconds = null;
     this.smoothedPose = {};
     this.lastOutputTimeSeconds = null;
+  }
+
+  private captureCurrentTransitionSource(): TransitionPlaybackSource | null {
+    if (this.activeClip) {
+      return {
+        clip: this.activeClip,
+        clipStartTimeSeconds: this.activeClipStartTimeSeconds,
+        fallbackPose: { ...this.latestPose },
+      };
+    }
+
+    if (Object.keys(this.latestPose).length > 0) {
+      return {
+        clip: null,
+        clipStartTimeSeconds: null,
+        fallbackPose: { ...this.latestPose },
+      };
+    }
+
+    return null;
+  }
+
+  private sampleClipForTransition(clip: ParsedIdleClip, elapsedSeconds: number): PoseValues {
+    const duration = Math.max(0.001, clip.durationSeconds);
+    if (clip.loop) {
+      return this.samplePoseWithLoopSeamBlend(clip, elapsedSeconds % duration);
+    }
+
+    return this.samplePose(clip, Math.min(Math.max(0, elapsedSeconds), duration));
+  }
+
+  private sampleTransitionSource(source: TransitionPlaybackSource, nowSeconds: number): PoseValues {
+    if (source.clip && source.clipStartTimeSeconds !== null) {
+      return this.sampleClipForTransition(
+        source.clip,
+        Math.max(0, nowSeconds - source.clipStartTimeSeconds),
+      );
+    }
+
+    return { ...source.fallbackPose };
   }
 
   private pushPose(pose: PoseValues): void {
@@ -779,7 +834,8 @@ export class RecordedIdleDriver {
     source: IdleClipSource,
     clipIndex: number,
   ): void {
-    const previousPose = this.latestPose;
+    const previousSource = this.queuedTransitionSource ?? this.captureCurrentTransitionSource();
+    this.queuedTransitionSource = null;
 
     if (source === 'bank' && clipIndex >= 0) {
       this.previousClipIndex = clipIndex;
@@ -789,11 +845,11 @@ export class RecordedIdleDriver {
     this.activeClipIndex = clipIndex;
     this.activeClip = parsedClip;
     this.activeClipStartTimeSeconds = nowSeconds;
-    this.transitionFromPose = Object.keys(previousPose).length > 0 ? { ...previousPose } : null;
-    this.transitionStartTimeSeconds = this.transitionFromPose ? nowSeconds : null;
+    this.transitionSource = previousSource;
+    this.transitionStartTimeSeconds = this.transitionSource ? nowSeconds : null;
 
     const initialPose = this.samplePoseWithLoopSeamBlend(parsedClip, 0);
-    this.pushPose(this.transitionFromPose ? blendPose(this.transitionFromPose, initialPose, 0) : initialPose);
+    this.pushPose(this.transitionSource ? blendPose(this.sampleTransitionSource(this.transitionSource, nowSeconds), initialPose, 0) : initialPose);
   }
 
   private async selectClip(

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -80,6 +80,7 @@
     "screen": "Screen",
     "browser": "Browser",
     "live": "Live",
+    "imageMessage": "Image attachment",
     "noMessages": "No messages yet. Start a conversation!",
     "noBrowserSession": "No active browser session",
     "browserSession": "Browser Session"

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -74,7 +74,8 @@
     "screenStopping": "Click to stop screen capture",
     "attachFile": "Attach file",
     "attachmentsCount": "{{count}} attachment(s)",
-    "removeAttachment": "Remove attachment"
+    "removeAttachment": "Remove attachment",
+    "previewAttachment": "Preview attachment"
   },
   "sidebar": {
     "camera": "Camera",

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -83,6 +83,7 @@
     "browser": "Browser",
     "live": "Live",
     "imageMessage": "Image attachment",
+    "previewImage": "Preview image",
     "noMessages": "No messages yet. Start a conversation!",
     "noBrowserSession": "No active browser session",
     "browserSession": "Browser Session"

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -73,7 +73,7 @@
     "screenControl": "Click to start screen capture",
     "screenStopping": "Click to stop screen capture",
     "attachFile": "Attach file",
-    "attachmentsCount": "{{count}} attachment(s)",
+    "attachmentsCount": "{{count}}/{{max}} attachment(s)",
     "removeAttachment": "Remove attachment",
     "previewAttachment": "Preview attachment"
   },
@@ -129,7 +129,8 @@
     "failedParseWebSocket": "Failed to parse WebSocket message",
     "unsupportedFileType": "Only image files can be attached.",
     "websocketNotOpen": "WebSocket is not open.",
-    "vadMisfire": "Voice detected but too brief. Try speaking louder/longer, or adjust settings (lower speech threshold, lower negative threshold, reduce redemption frames)."
+    "vadMisfire": "Voice detected but too brief. Try speaking louder/longer, or adjust settings (lower speech threshold, lower negative threshold, reduce redemption frames).",
+    "maxAttachmentsExceeded": "You can attach up to {{max}} files."
   },
   "aiState": {
     "idle": "idle",
@@ -144,4 +145,4 @@
     "connecting": "Connecting",
     "clickToReconnect": "Click to Reconnect"
   }
-} 
+}

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -73,7 +73,8 @@
     "screenControl": "Click to start screen capture",
     "screenStopping": "Click to stop screen capture",
     "attachFile": "Attach file",
-    "attachmentsCount": "{{count}} attachment(s)"
+    "attachmentsCount": "{{count}} attachment(s)",
+    "removeAttachment": "Remove attachment"
   },
   "sidebar": {
     "camera": "Camera",

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -71,7 +71,9 @@
     "cameraControl": "Click to start camera",
     "cameraStopping": "Click to stop camera",
     "screenControl": "Click to start screen capture",
-    "screenStopping": "Click to stop screen capture"
+    "screenStopping": "Click to stop screen capture",
+    "attachFile": "Attach file",
+    "attachmentsCount": "{{count}} attachment(s)"
   },
   "sidebar": {
     "camera": "Camera",
@@ -119,7 +121,9 @@
     "enterValidUuid": "Please enter a valid UUID",
     "cannotDeleteCurrentHistory": "Cannot delete current chat history",
     "failedCapture": "Failed to capture {{source}} frame",
+    "failedReadFile": "Failed to read attachment {{filename}}",
     "failedParseWebSocket": "Failed to parse WebSocket message",
+    "unsupportedFileType": "Only image files can be attached.",
     "websocketNotOpen": "WebSocket is not open.",
     "vadMisfire": "Voice detected but too brief. Try speaking louder/longer, or adjust settings (lower speech threshold, lower negative threshold, reduce redemption frames)."
   },

--- a/src/renderer/src/locales/en/translation.json
+++ b/src/renderer/src/locales/en/translation.json
@@ -127,6 +127,7 @@
     "failedCapture": "Failed to capture {{source}} frame",
     "failedReadFile": "Failed to read attachment {{filename}}",
     "failedParseWebSocket": "Failed to parse WebSocket message",
+    "ttsGenerationFailed": "Speech generation failed for this sentence and it was skipped.",
     "unsupportedFileType": "Only image files can be attached.",
     "websocketNotOpen": "WebSocket is not open.",
     "vadMisfire": "Voice detected but too brief. Try speaking louder/longer, or adjust settings (lower speech threshold, lower negative threshold, reduce redemption frames).",

--- a/src/renderer/src/locales/zh/translation.json
+++ b/src/renderer/src/locales/zh/translation.json
@@ -77,6 +77,7 @@
     "screen": "屏幕",
     "browser": "浏览器",
     "live": "直播",
+    "imageMessage": "图片附件",
     "noMessages": "暂无消息。开始对话吧！",
     "noBrowserSession": "无活跃浏览器会话",
     "browserSession": "浏览器会话"

--- a/src/renderer/src/locales/zh/translation.json
+++ b/src/renderer/src/locales/zh/translation.json
@@ -70,7 +70,7 @@
     "screenControl": "点击开始屏幕共享",
     "screenStopping": "点击停止屏幕共享",
     "attachFile": "上传文件",
-    "attachmentsCount": "已添加{{count}}个附件",
+    "attachmentsCount": "已添加{{count}}/{{max}}个附件",
     "removeAttachment": "移除附件",
     "previewAttachment": "预览附件"
   },
@@ -126,7 +126,8 @@
     "failedParseWebSocket": "解析WebSocket消息失败",
     "unsupportedFileType": "仅支持上传图片文件",
     "websocketNotOpen": "WebSocket未连接",
-    "vadMisfire": "检测到语音但过于简短，请尝试提高音量或说得更久一些，或调整识别设置（降低语音识别阈值、降低负面语音阈值、减少验证帧数）"
+    "vadMisfire": "检测到语音但过于简短，请尝试提高音量或说得更久一些，或调整识别设置（降低语音识别阈值、降低负面语音阈值、减少验证帧数）",
+    "maxAttachmentsExceeded": "最多只能上传{{max}}个附件"
   },
   "aiState": {
     "idle": "空闲",
@@ -141,4 +142,4 @@
     "connecting": "连接中",
     "clickToReconnect": "点击重新连接"
   }
-} 
+}

--- a/src/renderer/src/locales/zh/translation.json
+++ b/src/renderer/src/locales/zh/translation.json
@@ -68,7 +68,9 @@
     "cameraControl": "点击启动摄像头",
     "cameraStopping": "点击停止摄像头",
     "screenControl": "点击开始屏幕共享",
-    "screenStopping": "点击停止屏幕共享"
+    "screenStopping": "点击停止屏幕共享",
+    "attachFile": "上传文件",
+    "attachmentsCount": "已添加{{count}}个附件"
   },
   "sidebar": {
     "camera": "摄像头",
@@ -116,7 +118,9 @@
     "enterValidUuid": "请输入有效的UUID",
     "cannotDeleteCurrentHistory": "无法删除当前聊天记录",
     "failedCapture": "捕获{{source}}帧失败",
+    "failedReadFile": "读取附件{{filename}}失败",
     "failedParseWebSocket": "解析WebSocket消息失败",
+    "unsupportedFileType": "仅支持上传图片文件",
     "websocketNotOpen": "WebSocket未连接",
     "vadMisfire": "检测到语音但过于简短，请尝试提高音量或说得更久一些，或调整识别设置（降低语音识别阈值、降低负面语音阈值、减少验证帧数）"
   },

--- a/src/renderer/src/locales/zh/translation.json
+++ b/src/renderer/src/locales/zh/translation.json
@@ -80,6 +80,7 @@
     "browser": "浏览器",
     "live": "直播",
     "imageMessage": "图片附件",
+    "previewImage": "预览图片",
     "noMessages": "暂无消息。开始对话吧！",
     "noBrowserSession": "无活跃浏览器会话",
     "browserSession": "浏览器会话"

--- a/src/renderer/src/locales/zh/translation.json
+++ b/src/renderer/src/locales/zh/translation.json
@@ -70,7 +70,8 @@
     "screenControl": "点击开始屏幕共享",
     "screenStopping": "点击停止屏幕共享",
     "attachFile": "上传文件",
-    "attachmentsCount": "已添加{{count}}个附件"
+    "attachmentsCount": "已添加{{count}}个附件",
+    "removeAttachment": "移除附件"
   },
   "sidebar": {
     "camera": "摄像头",

--- a/src/renderer/src/locales/zh/translation.json
+++ b/src/renderer/src/locales/zh/translation.json
@@ -71,7 +71,8 @@
     "screenStopping": "点击停止屏幕共享",
     "attachFile": "上传文件",
     "attachmentsCount": "已添加{{count}}个附件",
-    "removeAttachment": "移除附件"
+    "removeAttachment": "移除附件",
+    "previewAttachment": "预览附件"
   },
   "sidebar": {
     "camera": "摄像头",

--- a/src/renderer/src/services/websocket-handler.tsx
+++ b/src/renderer/src/services/websocket-handler.tsx
@@ -21,6 +21,7 @@ import { useLocalStorage } from '@/hooks/utils/use-local-storage';
 import { useGroup } from '@/context/group-context';
 import { useInterrupt } from '@/hooks/utils/use-interrupt';
 import { useBrowser } from '@/context/browser-context';
+import { useMood } from '@/context/mood-context';
 
 function WebSocketHandler({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation();
@@ -40,6 +41,7 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
   const autoStartMicOnConvEndRef = useRef(autoStartMicOnConvEnd);
   const { interrupt } = useInterrupt();
   const { setBrowserViewData } = useBrowser();
+  const { setMoodScore } = useMood();
 
   useEffect(() => {
     autoStartMicOnConvEndRef.current = autoStartMicOnConvEnd;
@@ -125,6 +127,11 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
       case 'full-text':
         if (message.text) {
           setSubtitleText(message.text);
+        }
+        break;
+      case 'mood-update':
+        if (typeof message.score === 'number' && Number.isFinite(message.score)) {
+          setMoodScore(Math.min(100, Math.max(0, message.score)));
         }
         break;
       case 'config-files':
@@ -295,7 +302,7 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
       default:
         console.warn('Unknown message type:', message.type);
     }
-  }, [aiState, addAudioTask, appendHumanMessage, baseUrl, bgUrlContext, setAiState, setConfName, setConfUid, setConfigFiles, setCurrentHistoryUid, setHistoryList, setMessages, setModelInfo, setPersistentAppearance, setSubtitleText, startMic, stopMic, setSelfUid, setGroupMembers, setIsOwner, backendSynthComplete, setBackendSynthComplete, clearResponse, handleControlMessage, appendOrUpdateToolCallMessage, interrupt, setBrowserViewData, t]);
+  }, [aiState, addAudioTask, appendHumanMessage, baseUrl, bgUrlContext, setAiState, setConfName, setConfUid, setConfigFiles, setCurrentHistoryUid, setHistoryList, setMessages, setModelInfo, setPersistentAppearance, setSubtitleText, startMic, stopMic, setSelfUid, setGroupMembers, setIsOwner, backendSynthComplete, setBackendSynthComplete, clearResponse, handleControlMessage, appendOrUpdateToolCallMessage, interrupt, setBrowserViewData, setMoodScore, t]);
 
   useEffect(() => {
     wsService.connect(wsUrl);

--- a/src/renderer/src/services/websocket-handler.tsx
+++ b/src/renderer/src/services/websocket-handler.tsx
@@ -197,7 +197,7 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
   const { clearResponse, setForceNewMessage, appendHumanMessage, appendOrUpdateToolCallMessage } = useChatHistory();
   const { addAudioTask } = useAudioTask({ managePlaybackCompletion: true });
   const bgUrlContext = useBgUrl();
-  const { confUid, setConfName, setConfUid, setConfigFiles } = useConfig();
+  const { confUid, setConfName, setConfUid, setAsrEnabled, setConfigFiles } = useConfig();
   const [pendingModelInfo, setPendingModelInfo] = useState<ModelInfo | undefined>(undefined);
   const { setSelfUid, setGroupMembers, setIsOwner } = useGroup();
   const { startMic, stopMic, autoStartMicOnConvEnd } = useVAD();
@@ -364,6 +364,7 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
         if (message.client_uid) {
           setSelfUid(message.client_uid);
         }
+        setAsrEnabled(message.asr_enabled !== false);
         setPendingModelInfo(message.model_info);
         // setModelInfo(message.model_info);
         // We don't know when the confRef in live2d-config-context will be updated, so we set a delay here for convenience
@@ -503,8 +504,10 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
         toaster.create({
           title: message.message,
           type: 'error',
-          duration: 2000,
+          duration: 3000,
         });
+        // Reset AI state so "Thinking..." doesn't linger after an error
+        setAiState('idle');
         break;
       case 'group-update':
         console.log('Received group-update:', message.members);

--- a/src/renderer/src/services/websocket-handler.tsx
+++ b/src/renderer/src/services/websocket-handler.tsx
@@ -409,6 +409,21 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
         if (message.files) {
           bgUrlContext?.setBackgroundFiles(message.files);
         }
+        // Force background image reload after reconnection.
+        // The browser may have cached a failed request from when the backend
+        // wasn't running yet. Appending a cache-bust query forces a re-fetch.
+        if (bgUrlContext) {
+          const currentBg = bgUrlContext.backgroundUrl;
+          if (currentBg) {
+            try {
+              const url = new URL(currentBg.startsWith('http') ? currentBg : `${baseUrl}${currentBg}`);
+              url.searchParams.set('_t', String(Date.now()));
+              bgUrlContext.setBackgroundUrl(url.toString());
+            } catch {
+              bgUrlContext.resetBackground();
+            }
+          }
+        }
         break;
       case 'audio':
         if (message.turn_id && currentTurnIdRef.current && message.turn_id !== currentTurnIdRef.current) {

--- a/src/renderer/src/services/websocket-handler.tsx
+++ b/src/renderer/src/services/websocket-handler.tsx
@@ -555,6 +555,8 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
       case 'set-live2d-appearance': {
         if (typeof message.expression === 'string') {
           setPersistentAppearance(message.expression);
+        } else {
+          setPersistentAppearance(undefined);
         }
         break;
       }

--- a/src/renderer/src/services/websocket-handler.tsx
+++ b/src/renderer/src/services/websocket-handler.tsx
@@ -39,6 +39,7 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
   const { setSelfUid, setGroupMembers, setIsOwner } = useGroup();
   const { startMic, stopMic, autoStartMicOnConvEnd } = useVAD();
   const autoStartMicOnConvEndRef = useRef(autoStartMicOnConvEnd);
+  const currentTurnIdRef = useRef<string | null>(null);
   const { interrupt } = useInterrupt();
   const { setBrowserViewData } = useBrowser();
   const { setMoodScore } = useMood();
@@ -58,7 +59,8 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
     setCurrentHistoryUid, setMessages, setHistoryList,
   } = useChatHistory();
 
-  const handleControlMessage = useCallback((controlText: string) => {
+  const handleControlMessage = useCallback((message: MessageEvent) => {
+    const controlText = message.text;
     switch (controlText) {
       case 'start-mic':
         console.log('Starting microphone...');
@@ -69,11 +71,14 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
         stopMic();
         break;
       case 'conversation-chain-start':
+        currentTurnIdRef.current = message.turn_id || null;
+        setBackendSynthComplete(false);
         setAiState('thinking-speaking');
         audioTaskQueue.clearQueue();
         clearResponse();
         break;
       case 'conversation-chain-end':
+        currentTurnIdRef.current = null;
         audioTaskQueue.addTask(() => new Promise<void>((resolve) => {
           setAiState((currentState: AiState) => {
             if (currentState === 'thinking-speaking') {
@@ -91,15 +96,13 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
       default:
         console.warn('Unknown control command:', controlText);
     }
-  }, [setAiState, clearResponse, setForceNewMessage, startMic, stopMic]);
+  }, [clearResponse, setAiState, setBackendSynthComplete, startMic, stopMic]);
 
   const handleWebSocketMessage = useCallback((message: MessageEvent) => {
     console.log('Received message from server:', message);
     switch (message.type) {
       case 'control':
-        if (message.text) {
-          handleControlMessage(message.text);
-        }
+        handleControlMessage(message);
         break;
       case 'set-model-and-conf':
         setAiState('loading');
@@ -160,6 +163,10 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
         }
         break;
       case 'audio':
+        if (message.turn_id && currentTurnIdRef.current && message.turn_id !== currentTurnIdRef.current) {
+          console.log('Dropping stale audio payload for old turn:', message.turn_id);
+          break;
+        }
         if (aiState === 'interrupted' || aiState === 'listening') {
           console.log('Audio playback intercepted. Sentence:', message.display_text?.text);
         } else {
@@ -171,6 +178,7 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
             displayText: message.display_text || null,
             expressions: message.actions?.expressions || null,
             forwarded: message.forwarded || false,
+            turnId: message.turn_id,
           });
         }
         break;
@@ -251,7 +259,9 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
         });
         break;
       case 'backend-synth-complete':
-        setBackendSynthComplete(true);
+        if (!message.turn_id || !currentTurnIdRef.current || message.turn_id === currentTurnIdRef.current) {
+          setBackendSynthComplete(true);
+        }
         break;
       case 'conversation-chain-end':
         if (!audioTaskQueue.hasTask()) {

--- a/src/renderer/src/services/websocket-handler.tsx
+++ b/src/renderer/src/services/websocket-handler.tsx
@@ -22,6 +22,144 @@ import { useGroup } from '@/context/group-context';
 import { useInterrupt } from '@/hooks/utils/use-interrupt';
 import { useBrowser } from '@/context/browser-context';
 import { useMood } from '@/context/mood-context';
+import { getLive2DPoseMixerController } from '@/hooks/canvas/live2d-pose-mixer-controller';
+import { LOGICAL_CHANNELS, PoseValues } from '@/live2d/mixer/logical-channels';
+import { IdleBankConfig, IdlePlayCommand, normalizeIdleBankConfig } from '@/live2d/mixer/recorded-idle-driver';
+import type { PoseLayerId } from '@/hooks/canvas/live2d-pose-mixer-controller';
+
+function normalizeBackendPose(input: unknown): PoseValues {
+  if (!input || typeof input !== 'object') {
+    return {};
+  }
+
+  const source = input as Record<string, unknown>;
+  const values: PoseValues = {};
+
+  LOGICAL_CHANNELS.forEach((channel) => {
+    const value = source[channel];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      values[channel] = value;
+    }
+  });
+
+  return values;
+}
+
+const MIXER_LAYER_IDS: PoseLayerId[] = [
+  'idle_layer',
+  'speech_layer',
+  'backend_pose_layer',
+  'mouse_attention_layer',
+];
+
+function normalizeMixerWeights(input: unknown): Partial<Record<PoseLayerId, number>> {
+  if (!input || typeof input !== 'object') {
+    return {};
+  }
+
+  const source = input as Record<string, unknown>;
+  const weights: Partial<Record<PoseLayerId, number>> = {};
+  MIXER_LAYER_IDS.forEach((layerId) => {
+    const raw = source[layerId];
+    if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) {
+      weights[layerId] = raw;
+    }
+  });
+  return weights;
+}
+
+function applyMixerWeights(
+  controller: ReturnType<typeof getLive2DPoseMixerController>,
+  payload: { mixer_weights?: unknown; mixer_weights_mode?: 'patch' | 'reset' | null | undefined },
+): void {
+  if (payload.mixer_weights_mode === 'reset') {
+    controller.resetLayerWeights();
+  }
+
+  const nextWeights = normalizeMixerWeights(payload.mixer_weights);
+  if (Object.keys(nextWeights).length > 0) {
+    controller.patchLayerWeights(nextWeights);
+  }
+}
+
+function resolveIdleBankFromActions(actions: MessageEvent['actions']): IdleBankConfig | null {
+  if (!actions) {
+    return null;
+  }
+
+  if ('idle_bank' in actions) {
+    return normalizeIdleBankConfig(actions.idle_bank ?? null);
+  }
+
+  if (!('idle_list' in actions)) {
+    return null;
+  }
+
+  const clips = Array.isArray(actions.idle_list)
+    ? actions.idle_list
+      .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+      .map((url) => ({ url: url.trim() }))
+    : [];
+
+  if (clips.length === 0) {
+    return null;
+  }
+
+  return normalizeIdleBankConfig({
+    clips,
+    mode: actions.idle_mode ?? 'random_no_repeat',
+  });
+}
+
+function resolveIdleBankFromMessage(message: MessageEvent): IdleBankConfig | null {
+  if ('idle_bank' in message) {
+    return normalizeIdleBankConfig(message.idle_bank ?? null);
+  }
+
+  if (!('idle_list' in message)) {
+    return null;
+  }
+
+  const clips = Array.isArray(message.idle_list)
+    ? message.idle_list
+      .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+      .map((url) => ({ url: url.trim() }))
+    : [];
+
+  if (clips.length === 0) {
+    return null;
+  }
+
+  return normalizeIdleBankConfig({
+    clips,
+    mode: message.idle_mode ?? 'random_no_repeat',
+  });
+}
+
+function resolveIdleStateFromMessage(message: MessageEvent): string | null {
+  const actionState = message.actions?.idle_state;
+  if (typeof actionState === 'string' && actionState.trim()) {
+    return actionState.trim();
+  }
+
+  if (typeof message.idle_state === 'string' && message.idle_state.trim()) {
+    return message.idle_state.trim();
+  }
+
+  return null;
+}
+
+function resolveIdlePlayFromMessage(message: MessageEvent): IdlePlayCommand | string | null {
+  if (message.actions && 'idle_play' in message.actions) {
+    return message.actions.idle_play ?? null;
+  }
+
+  if ('idle_play' in message) {
+    return message.idle_play ?? null;
+  }
+
+  return null;
+}
 
 function WebSocketHandler({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation();
@@ -100,9 +238,96 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
 
   const handleWebSocketMessage = useCallback((message: MessageEvent) => {
     console.log('Received message from server:', message);
+
+    // Minimal backend -> mixer bridge (P1.5): if the backend sends logical pose in actions,
+    // route it into backend_pose_layer only. This intentionally does NOT touch expressions/motions.
+    if (message.actions && ('pose' in message.actions || 'pose_patch' in message.actions)) {
+      const controller = getLive2DPoseMixerController();
+      const hasPosePatch = 'pose_patch' in message.actions;
+      const mode = message.actions.pose_mode ?? 'set';
+      const weight = typeof message.actions.pose_weight === 'number' && Number.isFinite(message.actions.pose_weight)
+        ? message.actions.pose_weight
+        : undefined;
+
+      if (mode === 'clear' || message.actions.pose === null || message.actions.pose_patch === null) {
+        controller.clearBackendPose();
+      } else if (mode === 'patch' || hasPosePatch) {
+        // `patch` preserves previous backend channels and updates only provided keys.
+        // `pose_patch` defaults to patch semantics for streaming/incremental backends.
+        const patchPose = hasPosePatch ? message.actions.pose_patch : message.actions.pose;
+        controller.patchBackendPose(normalizeBackendPose(patchPose), weight);
+      } else {
+        // Default `set` is safer for full-pose payloads to avoid stale channel carry-over.
+        controller.setBackendPose(normalizeBackendPose(message.actions.pose), weight);
+      }
+    }
+
+    if (message.actions && ('idle_bank' in message.actions || 'idle_list' in message.actions)) {
+      const controller = getLive2DPoseMixerController();
+      const idleBank = resolveIdleBankFromActions(message.actions);
+      controller.setIdleRuntimeState(resolveIdleStateFromMessage(message));
+      if (idleBank) {
+        controller.setRecordedIdleBank(idleBank);
+      } else {
+        controller.clearRecordedIdleBank();
+      }
+    }
+
+    if (message.actions && ('mixer_weights' in message.actions || message.actions.mixer_weights_mode === 'reset')) {
+      const controller = getLive2DPoseMixerController();
+      controller.setIdleRuntimeState(resolveIdleStateFromMessage(message));
+      applyMixerWeights(controller, {
+        mixer_weights: message.actions.mixer_weights,
+        mixer_weights_mode: message.actions.mixer_weights_mode,
+      });
+    }
+
+    if (message.type === 'set-live2d-mixer-weights' || 'mixer_weights' in message || message.mixer_weights_mode === 'reset') {
+      const controller = getLive2DPoseMixerController();
+      controller.setIdleRuntimeState(resolveIdleStateFromMessage(message));
+      applyMixerWeights(controller, {
+        mixer_weights: message.mixer_weights,
+        mixer_weights_mode: message.mixer_weights_mode,
+      });
+    }
+
+    if (message.type === 'set-live2d-idle-bank') {
+      const controller = getLive2DPoseMixerController();
+      controller.setIdleRuntimeState(resolveIdleStateFromMessage(message));
+      const idleBank = resolveIdleBankFromMessage(message);
+      if (idleBank) {
+        controller.setRecordedIdleBank(idleBank);
+      } else {
+        controller.clearRecordedIdleBank();
+      }
+    }
+
+    if (
+      (message.actions && 'idle_play' in message.actions)
+      || message.type === 'set-live2d-idle-play'
+      || 'idle_play' in message
+    ) {
+      const controller = getLive2DPoseMixerController();
+      controller.setIdleRuntimeState(resolveIdleStateFromMessage(message));
+      controller.playRecordedIdleClip(resolveIdlePlayFromMessage(message));
+    }
+
     switch (message.type) {
       case 'control':
         handleControlMessage(message);
+        break;
+      case 'pose':
+      case 'live2d-pose':
+        // `actions.pose` is handled above (P1 mixer bridge).
+        break;
+      case 'set-live2d-idle-bank':
+        // handled above as a dedicated live2d control message.
+        break;
+      case 'set-live2d-mixer-weights':
+        // handled above as a dedicated live2d control message.
+        break;
+      case 'set-live2d-idle-play':
+        // handled above as a dedicated recorded-idle trigger.
         break;
       case 'set-model-and-conf':
         setAiState('loading');
@@ -331,6 +556,7 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
     sendMessage: wsService.sendMessage.bind(wsService),
     wsState,
     reconnect: () => wsService.connect(wsUrl),
+    disconnect: () => wsService.disconnect(),
     wsUrl,
     setWsUrl,
     baseUrl,

--- a/src/renderer/src/services/websocket-handler.tsx
+++ b/src/renderer/src/services/websocket-handler.tsx
@@ -82,6 +82,31 @@ function applyMixerWeights(
   }
 }
 
+function hasConcreteIdleBankInActions(actions: MessageEvent['actions']): boolean {
+  if (!actions) {
+    return false;
+  }
+
+  if (actions.idle_bank && typeof actions.idle_bank === 'object') {
+    return true;
+  }
+
+  return Array.isArray(actions.idle_list)
+    && actions.idle_list.some((entry) => typeof entry === 'string' && entry.trim().length > 0);
+}
+
+function hasConcreteMixerWeightsInActions(actions: MessageEvent['actions']): boolean {
+  if (!actions) {
+    return false;
+  }
+
+  if (actions.mixer_weights_mode === 'reset') {
+    return true;
+  }
+
+  return Object.keys(normalizeMixerWeights(actions.mixer_weights)).length > 0;
+}
+
 function resolveIdleBankFromActions(actions: MessageEvent['actions']): IdleBankConfig | null {
   if (!actions) {
     return null;
@@ -262,18 +287,16 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
       }
     }
 
-    if (message.actions && ('idle_bank' in message.actions || 'idle_list' in message.actions)) {
+    if (message.actions && hasConcreteIdleBankInActions(message.actions)) {
       const controller = getLive2DPoseMixerController();
       const idleBank = resolveIdleBankFromActions(message.actions);
       controller.setIdleRuntimeState(resolveIdleStateFromMessage(message));
       if (idleBank) {
         controller.setRecordedIdleBank(idleBank);
-      } else {
-        controller.clearRecordedIdleBank();
       }
     }
 
-    if (message.actions && ('mixer_weights' in message.actions || message.actions.mixer_weights_mode === 'reset')) {
+    if (message.actions && hasConcreteMixerWeightsInActions(message.actions)) {
       const controller = getLive2DPoseMixerController();
       controller.setIdleRuntimeState(resolveIdleStateFromMessage(message));
       applyMixerWeights(controller, {

--- a/src/renderer/src/services/websocket-handler.tsx
+++ b/src/renderer/src/services/websocket-handler.tsx
@@ -427,6 +427,7 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
             expressions: message.actions?.expressions || null,
             forwarded: message.forwarded || false,
             turnId: message.turn_id,
+            ttsError: Boolean(message.tts_error),
           });
         }
         break;

--- a/src/renderer/src/services/websocket-handler.tsx
+++ b/src/renderer/src/services/websocket-handler.tsx
@@ -28,7 +28,7 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
   const [wsUrl, setWsUrl] = useLocalStorage<string>('wsUrl', defaultWsUrl);
   const [baseUrl, setBaseUrl] = useLocalStorage<string>('baseUrl', defaultBaseUrl);
   const { aiState, setAiState, backendSynthComplete, setBackendSynthComplete } = useAiState();
-  const { setModelInfo } = useLive2DConfig();
+  const { setModelInfo, setPersistentAppearance } = useLive2DConfig();
   const { setSubtitleText } = useSubtitle();
   const { clearResponse, setForceNewMessage, appendHumanMessage, appendOrUpdateToolCallMessage } = useChatHistory();
   const { addAudioTask } = useAudioTask();
@@ -286,10 +286,16 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
           console.warn('Received incomplete tool_call_status message:', message);
         }
         break;
+      case 'set-live2d-appearance': {
+        if (typeof message.expression === 'string') {
+          setPersistentAppearance(message.expression);
+        }
+        break;
+      }
       default:
         console.warn('Unknown message type:', message.type);
     }
-  }, [aiState, addAudioTask, appendHumanMessage, baseUrl, bgUrlContext, setAiState, setConfName, setConfUid, setConfigFiles, setCurrentHistoryUid, setHistoryList, setMessages, setModelInfo, setSubtitleText, startMic, stopMic, setSelfUid, setGroupMembers, setIsOwner, backendSynthComplete, setBackendSynthComplete, clearResponse, handleControlMessage, appendOrUpdateToolCallMessage, interrupt, setBrowserViewData, t]);
+  }, [aiState, addAudioTask, appendHumanMessage, baseUrl, bgUrlContext, setAiState, setConfName, setConfUid, setConfigFiles, setCurrentHistoryUid, setHistoryList, setMessages, setModelInfo, setPersistentAppearance, setSubtitleText, startMic, stopMic, setSelfUid, setGroupMembers, setIsOwner, backendSynthComplete, setBackendSynthComplete, clearResponse, handleControlMessage, appendOrUpdateToolCallMessage, interrupt, setBrowserViewData, t]);
 
   useEffect(() => {
     wsService.connect(wsUrl);

--- a/src/renderer/src/services/websocket-handler.tsx
+++ b/src/renderer/src/services/websocket-handler.tsx
@@ -10,7 +10,7 @@ import {
 import { ModelInfo, useLive2DConfig } from '@/context/live2d-config-context';
 import { useSubtitle } from '@/context/subtitle-context';
 import { audioTaskQueue } from '@/utils/task-queue';
-import { useAudioTask } from '@/components/canvas/live2d';
+import { useAudioTask } from '@/hooks/utils/use-audio-task';
 import { useBgUrl } from '@/context/bgurl-context';
 import { useConfig } from '@/context/character-config-context';
 import { useChatHistory } from '@/context/chat-history-context';
@@ -170,7 +170,7 @@ function WebSocketHandler({ children }: { children: React.ReactNode }) {
   const { setModelInfo, setPersistentAppearance } = useLive2DConfig();
   const { setSubtitleText } = useSubtitle();
   const { clearResponse, setForceNewMessage, appendHumanMessage, appendOrUpdateToolCallMessage } = useChatHistory();
-  const { addAudioTask } = useAudioTask();
+  const { addAudioTask } = useAudioTask({ managePlaybackCompletion: true });
   const bgUrlContext = useBgUrl();
   const { confUid, setConfName, setConfUid, setConfigFiles } = useConfig();
   const [pendingModelInfo, setPendingModelInfo] = useState<ModelInfo | undefined>(undefined);

--- a/src/renderer/src/services/websocket-service.tsx
+++ b/src/renderer/src/services/websocket-service.tsx
@@ -6,6 +6,7 @@ import { ModelInfo } from '@/context/live2d-config-context';
 import { HistoryInfo } from '@/context/websocket-context';
 import { ConfigFile } from '@/context/character-config-context';
 import { toaster } from '@/components/ui/toaster';
+import { ImagePayload } from '@/types/media';
 
 export interface DisplayText {
   text: string;
@@ -34,6 +35,7 @@ export interface Message {
   timestamp: string;
   name?: string;
   avatar?: string;
+  images?: ImagePayload[];
 
   // Fields for different message types (make optional)
   type?: 'text' | 'tool_call_status'; // Add possible types, default to 'text' if omitted

--- a/src/renderer/src/services/websocket-service.tsx
+++ b/src/renderer/src/services/websocket-service.tsx
@@ -30,6 +30,7 @@ export interface AudioPayload {
   display_text?: DisplayText;
   actions?: Actions;
   turn_id?: string;
+  tts_error?: boolean;
 }
 
 export interface Message {
@@ -107,6 +108,7 @@ export interface MessageEvent {
   forwarded?: boolean;
   display_text?: DisplayText;
   turn_id?: string;
+  tts_error?: boolean;
   live2d_model?: string;
   expression?: string | number;
   idle_state?: string;

--- a/src/renderer/src/services/websocket-service.tsx
+++ b/src/renderer/src/services/websocket-service.tsx
@@ -80,6 +80,7 @@ export interface MessageEvent {
   forwarded?: boolean;
   display_text?: DisplayText;
   live2d_model?: string;
+  expression?: string | number;
   browser_view?: {
     debuggerFullscreenUrl: string;
     debuggerUrl: string;

--- a/src/renderer/src/services/websocket-service.tsx
+++ b/src/renderer/src/services/websocket-service.tsx
@@ -74,6 +74,7 @@ export interface MessageEvent {
   histories?: HistoryInfo[];
   configs?: ConfigFile[];
   message?: string;
+  score?: number;
   members?: string[];
   is_owner?: boolean;
   client_uid?: string;

--- a/src/renderer/src/services/websocket-service.tsx
+++ b/src/renderer/src/services/websocket-service.tsx
@@ -26,6 +26,7 @@ export interface AudioPayload {
   slice_length?: number;
   display_text?: DisplayText;
   actions?: Actions;
+  turn_id?: string;
 }
 
 export interface Message {
@@ -80,6 +81,7 @@ export interface MessageEvent {
   client_uid?: string;
   forwarded?: boolean;
   display_text?: DisplayText;
+  turn_id?: string;
   live2d_model?: string;
   expression?: string | number;
   browser_view?: {

--- a/src/renderer/src/services/websocket-service.tsx
+++ b/src/renderer/src/services/websocket-service.tsx
@@ -7,6 +7,9 @@ import { HistoryInfo } from '@/context/websocket-context';
 import { ConfigFile } from '@/context/character-config-context';
 import { toaster } from '@/components/ui/toaster';
 import { ImagePayload } from '@/types/media';
+import { PoseValues } from '@/live2d/mixer/logical-channels';
+import { IdleBankConfig, IdlePlaybackMode, IdlePlayCommand } from '@/live2d/mixer/recorded-idle-driver';
+import type { PoseLayerId } from '@/hooks/canvas/live2d-pose-mixer-controller';
 
 export interface DisplayText {
   text: string;
@@ -49,6 +52,28 @@ export interface Actions {
   expressions?: string[] | number [];
   pictures?: string[];
   sounds?: string[];
+
+  /**
+   * Minimal logical pose input for the Live2D pose mixer (backend_pose_layer).
+   * Values are logical channels (normalized), not raw Live2D parameter IDs.
+   */
+  pose?: PoseValues | null;
+  pose_patch?: PoseValues | null;
+  pose_mode?: 'set' | 'patch' | 'clear';
+  pose_weight?: number;
+  mixer_weights?: Partial<Record<PoseLayerId, number>>;
+  mixer_weights_mode?: 'patch' | 'reset';
+
+  /**
+   * Minimal recorded-idle inputs (P2):
+   * - `idle_list` is the compact shape for quick integration.
+   * - `idle_bank` is a structured form for future metadata (weight/scene/mood).
+   */
+  idle_list?: string[] | null;
+  idle_mode?: IdlePlaybackMode;
+  idle_bank?: IdleBankConfig | null;
+  idle_state?: string;
+  idle_play?: IdlePlayCommand | string | null;
 }
 
 export interface MessageEvent {
@@ -84,6 +109,13 @@ export interface MessageEvent {
   turn_id?: string;
   live2d_model?: string;
   expression?: string | number;
+  idle_state?: string;
+  idle_list?: string[] | null;
+  idle_mode?: IdlePlaybackMode;
+  idle_bank?: IdleBankConfig | null;
+  mixer_weights?: Partial<Record<PoseLayerId, number>>;
+  mixer_weights_mode?: 'patch' | 'reset';
+  idle_play?: IdlePlayCommand | string | null;
   browser_view?: {
     debuggerFullscreenUrl: string;
     debuggerUrl: string;

--- a/src/renderer/src/types/media.ts
+++ b/src/renderer/src/types/media.ts
@@ -1,0 +1,5 @@
+export interface ImagePayload {
+  source: 'camera' | 'screen' | 'upload';
+  data: string;
+  mime_type: string;
+}

--- a/src/renderer/src/utils/audio-manager.ts
+++ b/src/renderer/src/utils/audio-manager.ts
@@ -5,13 +5,15 @@
 class AudioManager {
   private currentAudio: HTMLAudioElement | null = null;
   private currentModel: any | null = null;
+  private currentStopCallback: (() => void) | null = null;
 
   /**
    * Set the current playing audio
    */
-  setCurrentAudio(audio: HTMLAudioElement, model: any) {
+  setCurrentAudio(audio: HTMLAudioElement, model: any, onStop?: (() => void) | null) {
     this.currentAudio = audio;
     this.currentModel = model;
+    this.currentStopCallback = onStop ?? null;
   }
 
   /**
@@ -21,7 +23,8 @@ class AudioManager {
     if (this.currentAudio) {
       console.log('[AudioManager] Stopping current audio and lip sync');
       const audio = this.currentAudio;
-      
+      const stopCallback = this.currentStopCallback;
+
       // Stop audio playback
       audio.pause();
       audio.src = '';
@@ -52,6 +55,15 @@ class AudioManager {
       // Clear references
       this.currentAudio = null;
       this.currentModel = null;
+      this.currentStopCallback = null;
+
+      if (stopCallback) {
+        try {
+          stopCallback();
+        } catch (e) {
+          console.error('[AudioManager] Error running stop callback:', e);
+        }
+      }
     } else {
       console.log('[AudioManager] No current audio playing to stop.');
     }
@@ -64,6 +76,7 @@ class AudioManager {
     if (this.currentAudio === audio) {
       this.currentAudio = null;
       this.currentModel = null;
+      this.currentStopCallback = null;
     }
   }
 

--- a/src/renderer/src/utils/task-queue.ts
+++ b/src/renderer/src/utils/task-queue.ts
@@ -22,8 +22,6 @@ export class TaskQueue {
 
   clearQueue() {
     this.queue = [];
-    this.activeTasks.clear();
-    this.running = false;
   }
 
   private async runNextTask() {


### PR DESCRIPTION
- XnneHangLab/Open-LLM-VTuber-Web#1
- XnneHangLab/Open-LLM-VTuber-Web#2
- XnneHangLab/Open-LLM-VTuber-Web#3
- XnneHangLab/Open-LLM-VTuber-Web#4
- XnneHangLab/Open-LLM-VTuber-Web#5
- XnneHangLab/Open-LLM-VTuber-Web#6
- XnneHangLab/Open-LLM-VTuber-Web#7
- MrXnneHang/Open-LLM-VTuber-Web-Dev#1


似乎原来的上传附件的 button click 事件没写。

这里添加了:
- click 事件，触发后选择文件，但限制 image type
- 上传图片的缩略图预览
- 通过缩略图移除附件
- 缩略图放大预览
- 对话历史中的显示缩略图
- 和对话历史的缩略图放大预览

因为我后端对话历史是不存 image 的，所以：
- 二次加载对话历史图片是不可见的。
- 另外似乎 `clamp(1vh, calc(110px - 5vh), 1000vh)':` 这个只是做了近似，某些分辨率，在某些窗口大小下可能表现不佳。

维护者似乎不在 =-=

但 PR 我先挂在这了。

<img width="640" height="415" alt="image" src="https://github.com/user-attachments/assets/587fa17d-6e7a-4f94-960c-b73d331c9af6" />
<img width="640" height="415" alt="image" src="https://github.com/user-attachments/assets/8e3eb91e-37a3-4e37-b5ef-897e6ea44563" />
<img width="640" height="415" alt="image" src="https://github.com/user-attachments/assets/c3ade5e0-aeac-4580-a2af-af5885162626" />
<img width="640" height="415" alt="image" src="https://github.com/user-attachments/assets/889b4ecd-bd69-4d97-8a5e-d8945a264af0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image attachments for chat messages with preview and fullscreen modal display
  * Mood/emotion tracking system with visual indicators
  * Advanced character pose and appearance blending
  * Configurable voice input (ASR) toggle

* **Improvements**
  * Enhanced mouse-following and drag interaction handling
  * Dynamic window sizing and render scaling
  * Refined WebSocket status interaction and disconnect controls
  * Better footer responsiveness with attachment support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->